### PR TITLE
開発環境が仮想マシン上にある場合、ホストマシンから開発環境にアクセスできるように説明を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ bundle install
 $ bundle exec rake db:create
 $ bundle exec rake db:migrate
 $ bundle exec rake db:seed
-$ bundle exec rails s
+$ bundle exec rails s -b 0.0.0.0
 ```
 
 [http://localhost:3000](http://localhost:3000) にアクセスすると、


### PR DESCRIPTION
[Rails 4.2のリリースノート](http://railsguides.jp/4_2_release_notes.html#rails-server%E3%81%AE%E3%83%87%E3%83%95%E3%82%A9%E3%83%AB%E3%83%88%E3%83%9B%E3%82%B9%E3%83%88)に書いてあるように、Rails 4.2からは[Rackの変更](https://github.com/rack/rack/commit/28b014484a8ac0bbb388e7eaeeef159598ec64fc)によりデフォルトホストが変わった影響で、Vagrantなどで開発環境を用意しているとポートフォワーディングしても開発環境にアクセスできない状態のままのREADMEだったので、`bundle exec rails s`に`-b 0.0.0.0`オプションをつけ、仮想マシンで開発環境を動かしているときでもアクセスできるようにREADMEを一部修正しました。
