### PR TITLE
DRY `require 'spec_helper'`

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --format documentation
+--require spec_helper

--- a/spec/controllers/api/tips_controller_spec.rb
+++ b/spec/controllers/api/tips_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Api::TipsController do
   let(:user) { create(:registered_user) }
   let(:tip) { create(:status_tip) }

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe StatusesController do
   let(:user) { create(:registered_user) }
   let(:work) { create(:work) }

--- a/spec/features/channel_works_spec.rb
+++ b/spec/features/channel_works_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe '作品別チャンネル設定ページ' do
   let(:user) { create(:registered_user) }
   let(:episode) { create(:episode) }

--- a/spec/features/episodes_spec.rb
+++ b/spec/features/episodes_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'エピソード詳細ページ' do
   let(:work)    { create(:work, :with_item) }
   let(:episode) { create(:episode, work: work) }

--- a/spec/features/friends_spec.rb
+++ b/spec/features/friends_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe '友達ページ' do
   let(:user) { create(:registered_user) }
 

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'トップページ' do
 
   context 'ログインしていないとき' do

--- a/spec/features/notifications_spec.rb
+++ b/spec/features/notifications_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe '通知ページ' do
   context 'ユーザにフォローされたとき' do
     let(:user1) { create(:registered_user) }

--- a/spec/features/pages_spec.rb
+++ b/spec/features/pages_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'Annictについて' do
   context '未ログイン時' do
     before do

--- a/spec/features/programs_spec.rb
+++ b/spec/features/programs_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe '番組情報ページ' do
   let!(:status_tip) { create(:status_tip) }
   let(:user) { create(:registered_user) }

--- a/spec/features/registrations_spec.rb
+++ b/spec/features/registrations_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'ユーザ登録機能' do
   let!(:work) { create(:work, :with_item) }
   let!(:cover_image) { create(:cover_image, work: work) }

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe 'プロフィールページ' do
   let!(:checkin_tip) { create(:checkin_tip) }
   let(:user) { create(:registered_user) }

--- a/spec/features/works_spec.rb
+++ b/spec/features/works_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe "今期作品一覧ページ" do
   let!(:work) { create(:work, :with_item, :with_current_season) }
 

--- a/spec/models/episode_spec.rb
+++ b/spec/models/episode_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Episode do
   describe '#create_nicoch_program' do
     let!(:channel) { create(:channel, name: 'ニコニコチャンネル') }


### PR DESCRIPTION
.rspec に `--require spec_helper` と書いておけば、個々の spec ファイルで `require 'spec_helper'` しなくて良くなるため、ちょっとリーズナブルです。
