### PR TITLE
Replace try with try!

### DIFF
--- a/app/controllers/db/draft_programs_controller.rb
+++ b/app/controllers/db/draft_programs_controller.rb
@@ -25,7 +25,7 @@ class Db::DraftProgramsController < Db::ApplicationController
       @draft_program.origin = @program
     end
 
-    @draft_program.started_at = @draft_program.started_at.try(:-, 9.hours)
+    @draft_program.started_at = @draft_program.started_at.try!(:-, 9.hours)
     if @draft_program.valid?
       @draft_program.save(validate: false)
       flash[:notice] = "放送予定の編集リクエストを作成しました"
@@ -46,7 +46,7 @@ class Db::DraftProgramsController < Db::ApplicationController
 
     @draft_program.attributes = draft_program
 
-    @draft_program.started_at = @draft_program.started_at.try(:-, 9.hours)
+    @draft_program.started_at = @draft_program.started_at.try!(:-, 9.hours)
     if @draft_program.valid?
       @draft_program.save(validate: false)
       flash[:notice] = "エピソードの編集リクエストを更新しました"

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -32,8 +32,8 @@ class Check < ActiveRecord::Base
     checks = user.checks.includes(:work).where(episode_id: nil)
 
     checks.each do |check|
-      kind = user.statuses.kind_of(check.work).try(:kind)
-      unless %w(on_hold wanna_watch).include?(kind.try(:to_s))
+      kind = user.statuses.kind_of(check.work).try!(:kind)
+      unless %w(on_hold wanna_watch).include?(kind.try!(:to_s))
         check.update_episode_to_unchecked
       end
     end
@@ -53,7 +53,7 @@ class Check < ActiveRecord::Base
 
   def update_episode_to_next(options = {})
     model = options[:checkin].presence || self
-    next_episode = model.episode.try(:next_episode)
+    next_episode = model.episode.try!(:next_episode)
 
     if next_episode.present?
       update(episode_id: next_episode.id)

--- a/app/models/concerns/multiple_episodes_formatter.rb
+++ b/app/models/concerns/multiple_episodes_formatter.rb
@@ -10,8 +10,8 @@ module MultipleEpisodesFormatter
       body = self.body.gsub(/"/, "__double_quote__")
 
       CSV.parse(body).map do |ary|
-        title = ary[1].gsub("__double_quote__", '"').try(:strip) if ary[1].present?
-        { number: ary[0].try(:strip), title: title }
+        title = ary[1].gsub("__double_quote__", '"').try!(:strip) if ary[1].present?
+        { number: ary[0].try!(:strip), title: title }
       end
     end
   end

--- a/app/views/application/_status_selector.html.slim
+++ b/app/views/application/_status_selector.html.slim
@@ -1,4 +1,4 @@
-- status_kind = current_user.statuses.kind_of(work).try(:kind).presence || 'no_select'
+- status_kind = current_user.statuses.kind_of(work).try!(:kind).presence || 'no_select'
 
 .ann-status-selector data-work-id="#{work.id}" data-status-kind="#{status_kind}" data-mini-selector="#{mini}" ng-class='{"is-mini": isMini}'
   = render 'selector_spinner', target: work.id

--- a/app/views/db/draft_items/_form.html.slim
+++ b/app/views/db/draft_items/_form.html.slim
@@ -18,7 +18,7 @@
         = annict_image_tag(draft_item.origin, :tombo_image, size: "50x50")
       = f.file_field :tombo_image
     
-  = hidden_field_tag "draft_item[item_id]", (item.try(:id).presence || draft_item.try(:origin).try(:id))
+  = hidden_field_tag "draft_item[item_id]", (item.try!(:id).presence || draft_item.try!(:origin).try!(:id))
 
   hr
 

--- a/app/views/db/draft_programs/_form.html.slim
+++ b/app/views/db/draft_programs/_form.html.slim
@@ -3,7 +3,7 @@
 
   = render "db/programs/program_fields", f: f, work: work
     
-  = hidden_field_tag "draft_program[program_id]", (program.try(:id).presence || draft_program.try(:origin).try(:id))
+  = hidden_field_tag "draft_program[program_id]", (program.try!(:id).presence || draft_program.try!(:origin).try!(:id))
   
   hr
   

--- a/app/views/db/episodes/index.html.slim
+++ b/app/views/db/episodes/index.html.slim
@@ -40,7 +40,7 @@ table.table.table-striped
             = icon("check-circle-o", class: "status-published disabled", "data-toggle" => "tooltip", title: "このエピソードは非公開になっています")
         td = episode.number.presence || "-"
         td = episode.title.presence || "-"
-        td = episode.next_episode.try(:number).presence || "-"
+        td = episode.next_episode.try!(:number).presence || "-"
         td
           - if episode.fetch_syobocal?
             | 同期中

--- a/app/views/db/programs/_program_fields.html.slim
+++ b/app/views/db/programs/_program_fields.html.slim
@@ -1,12 +1,12 @@
 .form-group
   = f.label :channel_id, class: "col-sm-3 control-label"
   .col-sm-9
-    = f.select :channel_id, options_from_collection_for_select(Channel.published.order(:name), :id, :name, f.object.channel.try(:id)), { include_blank: true }, { class: "form-control" }
+    = f.select :channel_id, options_from_collection_for_select(Channel.published.order(:name), :id, :name, f.object.channel.try!(:id)), { include_blank: true }, { class: "form-control" }
 .form-group
   = f.label :episode_id, class: "col-sm-3 control-label"
   .col-sm-9
-    = f.select :episode_id, options_for_select(work.episodes.order(:sort_number).map { |episode| [episode.decorate.title_with_number, episode.id] }, f.object.episode.try(:id)), { include_blank: true }, { class: "form-control" }
+    = f.select :episode_id, options_for_select(work.episodes.order(:sort_number).map { |episode| [episode.decorate.title_with_number, episode.id] }, f.object.episode.try!(:id)), { include_blank: true }, { class: "form-control" }
 .form-group
   = f.label :started_at, class: "col-sm-3 control-label"
   .col-sm-9
-    = f.text_field :started_at, class: "form-control", value: f.object.started_at.try(:to_time).try(:strftime, "%Y-%m-%d %H:%M"), placeholder: "例: 2015-04-01 23:00"
+    = f.text_field :started_at, class: "form-control", value: f.object.started_at.try!(:to_time).try!(:strftime, "%Y-%m-%d %H:%M"), placeholder: "例: 2015-04-01 23:00"

--- a/app/views/db/programs/index.html.slim
+++ b/app/views/db/programs/index.html.slim
@@ -26,7 +26,7 @@ table.table.table-striped
         td = program.id
         td = program.channel.name
         td = program.episode.decorate.title_with_number
-        td = program.started_at.try(:to_time).try(:strftime, "%Y-%m-%d %H:%M")
+        td = program.started_at.try!(:to_time).try!(:strftime, "%Y-%m-%d %H:%M")
         td
           - if current_user.role.admin? || current_user.role.editor?
             = link_to "編集", edit_db_work_program_path(@work, program), class: "btn btn-primary btn-sm"

--- a/app/views/works/_channel_selector.html.slim
+++ b/app/views/works/_channel_selector.html.slim
@@ -1,4 +1,4 @@
-- current_channel_id = current_user.channel_works.current_channel(work).try(:id).presence || 'no_select'
+- current_channel_id = current_user.channel_works.current_channel(work).try!(:id).presence || 'no_select'
 
 .ann-channel-selector data-work-id="#{work.id}" data-channel-id="#{current_channel_id}" data-mini-selector="#{mini}" ng-class='{"is-mini": isMini}'
   = render 'selector_spinner', target: work.id


### PR DESCRIPTION
Rails 4 では try の引数に存在しないメソッド名を渡してもNoMethodError にならなくなったため、Rails 4 で導入されたtry! (Rails 3 での try 相当) を使った方が堅実な気がしました。
(Rails 4 での try は引数のメソッド名を typo してても nil が返ります)

try は NoMethodError を起こさないようになったコミットです。
https://github.com/rails/rails/commit/99ea1a875b06feb4346869f371e2a57a2cc0a0fc
