### PR TITLE
設定 > オプション > "他の利用者の感想を表示しない" の文言を変更

### DIFF
--- a/app/views/settings/show.html.slim
+++ b/app/views/settings/show.html.slim
@@ -76,7 +76,7 @@
       .checkbox
         label
           = f.check_box :hide_checkin_comment
-          | 他の利用者の感想を表示しない
+          | 未記録エピソードのネタバレを防ぐ
           .detail 見てる、見たい、または中断したアニメの中で、記録していないエピソードに投稿された他の利用者からの感想を表示しないようにします。
       .form-submit
         = f.submit class: 'btn btn-primary'


### PR DESCRIPTION
この PR は 設定 > オプション 内の "他の利用者の感想を表示しない" を "未記録エピソードのネタバレを防ぐ" に変更します (まったくの主観ですが、こちらのほうが直感的な感じがします)
