### PR TITLE
Integrated "did_you_mean" gem to ruby-core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,6 @@ gem "virtus"
 
 group :development, :test do
   gem "awesome_print"
-  gem "did_you_mean"
   gem "hirb-unicode"
   gem "hirb"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,6 @@ GEM
       responders
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
-    did_you_mean (1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.25)
@@ -635,7 +634,6 @@ DEPENDENCIES
   database_rewinder
   delayed_job_active_record
   devise
-  did_you_mean
   draper
   email_validator
   enumerize


### PR DESCRIPTION
Ruby 2.3 に上げられておりましたので、標準添付になった did_you_mean を Gemfile から外しておきました :santa:
