### PR TITLE
Add REDIS_URL to application.yml.example

### DIFF
--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -7,6 +7,8 @@ ANNICT_PAPERCLIP_RANDOM_SECRET: 'abcdefghijklmnopqrstuvwxyz'
 DEVISE_SECRET: 'abcdefghijklmnopqrstuvwxyz'
 RAILS_SECRET_KEY_BASE: 'abcdefghijklmnopqrstuvwxyz'
 
+REDIS_URL: 'redis:127.0.0.1:6379'
+
 development:
   FACEBOOK_APP_ID: '000000000000000'
   FACEBOOK_SECRET_KEY: 'xxxxxxxxxxxxxxxxxxxxxxxx'


### PR DESCRIPTION
e7144bf で REDIS_URL という環境変数が必要になっているようでしたので、redis を起動したときのデフォルトの url を application.yml.example に追加してみました。
