### PR TITLE
DB の「スタッフ/キャスト」「会社/団体」ページの "ID" をリンクにしてみました

### DIFF
--- a/app/views/db/organizations/_organizations_list.html.slim
+++ b/app/views/db/organizations/_organizations_list.html.slim
@@ -14,7 +14,7 @@ table.table.table-striped.c-resource-list
     - organizations.each do |organization|
       tr
         td
-          = organization.id
+          = link_to organization.id, organization_path(organization), target: "_blank"
           - if organization.published?
             = icon("check-circle-o", class: "c-resource-list__status-published enabled", "data-toggle" => "tooltip", title: "公開されています")
           - else

--- a/app/views/db/people/_people_list.html.slim
+++ b/app/views/db/people/_people_list.html.slim
@@ -14,7 +14,7 @@ table.table.table-striped.c-resource-list
     - people.each do |person|
       tr
         td
-          = person.id
+          = link_to person.id, person_path(person), target: "_blank"
           - if person.published?
             = icon("check-circle-o", class: "c-resource-list__status-published enabled", "data-toggle" => "tooltip", title: "公開されています")
           - else


### PR DESCRIPTION
新機能のリリース、おめでとうございます|ありがとうございます:christmas_tree: :+1: :fireworks: :tada: 

/db/works ではリストの ID が作品ページへのリンクになっているのに /db/people と /db/organizations ではリンクになっておらず、少し不便に感じたので対応してみました。
何か意図があってのことであれば close してください。

それから、リンク先が非公開の状態(aasm_state: "hidden")の場合は、リンクがあっても 404 になってしまうように思いますが、この場合はリンクでは無い方がよかったりしますか？
現状として /db/works ではそのようになっていなかったのでひとまず対応していないのですが、そっちの方が良ければあわせて対応しようかと :muscle: 

わかりづらいですが画像です。
<img width="460" alt="2016-02-25 02 28 25" src="https://cloud.githubusercontent.com/assets/1624768/13294485/84688afe-db67-11e5-934f-803cbfe7bcf1.png">
