### PR TITLE
Must install node dependencies before serving rails.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ $ cd annict
 $ cp config/application.yml{.example,}
 $ bundle
 $ rake db:setup
+$ npm install
 $ rails s -b 0.0.0.0
 ```
 


### PR DESCRIPTION
Serving rails before running npm will raise a `Unable to run node_modules/.bin/browserify. Ensure you have installed it with npm.` error.
