### PR TITLE
Season is no longer derived class of AR::Base since #757

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@
   Channel,
   NumberFormat,
   Prefecture,
-  Season,
+  SeasonModel,
   Tip,
   Work,
   Episode


### PR DESCRIPTION
This fixes NoMethodError while running `bin/rails db:setup`