### PR TITLE
Install tether by yarn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,3 @@ end
 group :production do
   gem "bugsnag"
 end
-
-source "https://rails-assets.org" do
-  gem "rails-assets-tether"
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,5 @@
 GEM
   remote: https://rubygems.org/
-  remote: https://rails-assets.org/
   specs:
     aasm (4.12.0)
       concurrent-ruby (~> 1.0)
@@ -420,7 +419,6 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.2)
       sprockets-rails (>= 2.0.0)
-    rails-assets-tether (1.4.0)
     rails-dom-testing (2.0.2)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6)
@@ -664,7 +662,6 @@ DEPENDENCIES
   rack-cors
   rack-rewrite
   rails (~> 5.0.0)
-  rails-assets-tether!
   rails-html-sanitizer
   rails-i18n
   rails_autolink
@@ -691,9 +688,8 @@ DEPENDENCIES
   validate_url
   virtus
 
-
 RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ cd annict
 $ cp config/application.yml{.example,}
 $ bundle
 $ rake db:setup
-$ npm install
+$ yarn
 $ rails s -b 0.0.0.0
 ```
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,7 +6,7 @@ Rails.application.config.assets.version = "1.0"
 %w(fonts).each do |dir_name|
   Rails.application.config.assets.paths << "#{Rails.root}/app/assets/#{dir_name}"
 end
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 Rails.application.config.assets.precompile += %w(
   db.scss

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,6 +6,7 @@ Rails.application.config.assets.version = "1.0"
 %w(fonts).each do |dir_name|
   Rails.application.config.assets.paths << "#{Rails.root}/app/assets/#{dir_name}"
 end
+Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 Rails.application.config.assets.precompile += %w(
   db.scss

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "mjml": "3.3.2",
     "moment-timezone": "0.5.13",
     "mousetrap": "1.6.1",
+    "tether": "1.4.0",
     "turbolinks": "5.0.0",
     "vue": "2.3.0",
     "vue-lazyload": "^1.0.0-rc12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2420,6 +2420,10 @@ tar@~2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+tether@1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/tether/-/tether-1.4.0.tgz#0f9fa171f75bf58485d8149e94799d7ae74d1c1a"
+
 thenify-all@^1.0.0, thenify-all@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"


### PR DESCRIPTION
Because Rails 5.1 started integrating yarn. Also, rails-assets is relatively
unstable and unreliable I think...