### PR TITLE
Remove deprecation warnings which are caused by FactoryBot

### DIFF
--- a/spec/factories/activity.rb
+++ b/spec/factories/activity.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     association :user
     association :recipient
     association :trackable
-    action "create_episode_record"
+    action { "create_episode_record" }
   end
 end

--- a/spec/factories/channel.rb
+++ b/spec/factories/channel.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :channel do
     association :channel_group
     sequence(:sc_chid)
-    name 'テレビ夕日'
+    name { "テレビ夕日" }
   end
 end

--- a/spec/factories/channel_group.rb
+++ b/spec/factories/channel_group.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :channel_group do
     sequence(:sc_chgid)
-    name 'テレビ 関東'
+    name { "テレビ 関東" }
   end
 end

--- a/spec/factories/episode_record.rb
+++ b/spec/factories/episode_record.rb
@@ -3,10 +3,10 @@
 FactoryBot.define do
   factory :episode_record do
     association :user, :with_profile
-    comment "おもしろかった"
-    twitter_url_hash "xxxxx"
+    comment { "おもしろかった" }
+    twitter_url_hash { "xxxxx" }
     episode
-    rating 3.0
+    rating { 3.0 }
 
     before(:create) do |episode_record|
       Tip.where(slug: "record").first_or_create(attributes_for(:record_tip))

--- a/spec/factories/item.rb
+++ b/spec/factories/item.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :item do
-    name "プリキュアのDVD"
-    url "http://amazon.co.jp"
-    tombo_image File.open("#{Rails.root}/public/images/no_image.png")
+    name { "プリキュアのDVD" }
+    url { "http://amazon.co.jp" }
+    tombo_image { File.open("#{Rails.root}/public/images/no_image.png") }
   end
 end

--- a/spec/factories/oauth_access_token.rb
+++ b/spec/factories/oauth_access_token.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
     association :application, factory: :oauth_application
     owner { application.owner }
     sequence(:token) { |n| "token#{n}" }
-    scopes "read write"
+    scopes { "read write" }
   end
 end

--- a/spec/factories/oauth_application.rb
+++ b/spec/factories/oauth_application.rb
@@ -5,8 +5,8 @@ FactoryBot.define do
     sequence(:name) { |n| "App name #{n}" }
     sequence(:uid) { |n| "uid#{n}" }
     sequence(:secret) { |n| "secret#{n}" }
-    redirect_uri "https://example.com"
-    scopes "read write"
+    redirect_uri { "https://example.com" }
+    scopes { "read write" }
     association :owner, factory: :registered_user
   end
 end

--- a/spec/factories/profile.rb
+++ b/spec/factories/profile.rb
@@ -3,9 +3,9 @@
 FactoryBot.define do
   factory :profile do
     sequence(:name) { |n| "人造人間#{n}号" }
-    description "悟空を倒すために生まれました。よろしくお願いします。"
-    url "http://example.com"
-    tombo_avatar File.open("#{Rails.root}/public/images/no_image.png")
-    tombo_background_image File.open("#{Rails.root}/public/images/no_image.png")
+    description { "悟空を倒すために生まれました。よろしくお願いします。" }
+    url { "http://example.com" }
+    tombo_avatar { File.open("#{Rails.root}/public/images/no_image.png") }
+    tombo_background_image { File.open("#{Rails.root}/public/images/no_image.png") }
   end
 end

--- a/spec/factories/program.rb
+++ b/spec/factories/program.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :program do
     association :work
     association :episode
-    started_at Time.parse("2017-01-29 0:00:00")
+    started_at { Time.parse("2017-01-29 0:00:00") }
     channel
 
     before(:create) { |p| p.work = p.episode.work }

--- a/spec/factories/provider.rb
+++ b/spec/factories/provider.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :provider do
-    name         'twitter'
-    uid          { SecureRandom.hex }
-    token        'mock_token'
-    token_secret 'mock_secret'
+    name { "twitter" }
+    uid { SecureRandom.hex }
+    token { "mock_token" }
+    token_secret { "mock_secret" }
   end
 end

--- a/spec/factories/setting.rb
+++ b/spec/factories/setting.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :setting do
   end

--- a/spec/factories/status.rb
+++ b/spec/factories/status.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :status do
     association :user
     association :work
-    kind :watching
+    kind { :watching }
 
     before(:create) do
       attrs = attributes_for(:status_tip)

--- a/spec/factories/tip.rb
+++ b/spec/factories/tip.rb
@@ -2,23 +2,23 @@
 
 FactoryBot.define do
   factory :status_tip, class: Tip do
-    target 0
-    slug "status"
-    title "作品のステータスを変更しよう"
-    icon_name 0
+    target { 0 }
+    slug { "status" }
+    title { "作品のステータスを変更しよう" }
+    icon_name { 0 }
   end
 
   factory :channel_tip, class: Tip do
-    target 0
-    slug "channel"
-    title "チャンネルを設定しよう"
-    icon_name 0
+    target { 0 }
+    slug { "channel" }
+    title { "チャンネルを設定しよう" }
+    icon_name { 0 }
   end
 
   factory :record_tip, class: Tip do
-    target 0
-    slug "record"
-    title "エピソードを記録しよう"
-    icon_name 0
+    target { 0 }
+    slug { "record" }
+    title { "エピソードを記録しよう" }
+    icon_name { 0 }
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -4,8 +4,8 @@ FactoryBot.define do
   factory :user do
     sequence(:username) { |n| "user_#{n}" }
     sequence(:email)    { |n| "user_#{n}@example.com" }
-    time_zone "Asia/Tokyo"
-    locale "ja"
+    time_zone { "Asia/Tokyo" }
+    locale { "ja" }
 
     trait :with_profile do
       after(:create) do |user|
@@ -26,7 +26,7 @@ FactoryBot.define do
     end
 
     trait :with_editor_role do
-      role :editor
+      role { :editor }
     end
 
     factory :registered_user, traits: [:with_profile, :with_provider, :with_setting] do

--- a/spec/factories/work.rb
+++ b/spec/factories/work.rb
@@ -4,31 +4,31 @@ FactoryBot.define do
   factory :work do
     sequence(:title) { |n| "#{n}人はプリキュア" }
     sequence(:title_kana) { |n| "#{n}にんはぷりきゅあ" }
-    media :tv
-    official_site_url "http://example.com"
-    wikipedia_url "http://wikipedia.org"
-    twitter_username "precure_official"
-    twitter_hashtag "precure"
-    mal_anime_id 12345
-    released_at Date.parse("2012-04-05")
-    released_at_about "2012年"
+    media { :tv }
+    official_site_url { "http://example.com" }
+    wikipedia_url { "http://wikipedia.org" }
+    twitter_username { "precure_official" }
+    twitter_hashtag { "precure" }
+    mal_anime_id { 12_345 }
+    released_at { Date.parse("2012-04-05") }
+    released_at_about { "2012年" }
 
     trait :with_current_season do
       year, name = ENV["ANNICT_CURRENT_SEASON"].split("-")
-      season_year year
-      season_name name
+      season_year { year }
+      season_name { name }
     end
 
     trait :with_next_season do
       year, name = ENV["ANNICT_NEXT_SEASON"].split("-")
-      season_year year
-      season_name name
+      season_year { year }
+      season_name { name }
     end
 
     trait :with_prev_season do
       year, name = ENV["ANNICT_PREVIOUS_SEASON"].split("-")
-      season_year year
-      season_name name
+      season_year { year }
+      season_name { name }
     end
 
     trait :with_episode do


### PR DESCRIPTION
Like this:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block:

kind { :watching }
```