### PR TITLE
circleci/ruby -> shimbaco/ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     # directory where steps will run
     working_directory: ~/annict
     docker:
-      - image: circleci/ruby:2.6.0-node-browsers
+      - image: shimbaco/ruby:2.6.0-node_10.15.0
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_PATH: vendor/bundle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,14 @@ jobs:
           # https://github.com/jtoy/cld/issues/10
           CFLAGS: -Wno-narrowing
           CXXFLAGS: -Wno-narrowing
+          SELENIUM_DRIVER_URL: http://localhost:4444/wd/hub
       - image: circleci/postgres:10.4-alpine
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: annict_test
           POSTGRES_PASSWORD: ""
       - image: circleci/redis:4.0.11-alpine
+      - image: selenium/standalone-chrome:3.141.59
     steps:
       # special step to check out source code to working directory
       - checkout
@@ -76,6 +78,10 @@ jobs:
       - run:
           name: Wait for DB
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
+    
+      - run:
+          name: Wait for Selenium
+          command: dockerize -wait tcp://localhost:4444 -timeout 1m
 
       - run:
           name: Database setup


### PR DESCRIPTION
- RubyがリリースされてからDockerイメージが提供されるまでにいつも数日のラグがある
- Nodeのバージョンも固定したい

という理由から [circleci/ruby](https://hub.docker.com/r/circleci/ruby) から自前で用意した [shimbaco/ruby](https://hub.docker.com/r/shimbaco/ruby) ([GitHub](https://github.com/shimbaco/docker-ruby)) に移行します。
shimbaco/ruby ではRubyとNodeだけ面倒を見たかったので、Chromeは [selenium/standalone-chrome](https://hub.docker.com/r/selenium/standalone-chrome) を使うことにしました。