### PR TITLE
fix #1660

### DIFF
--- a/app/frontend/stylesheets/common/components/appbar.scss
+++ b/app/frontend/stylesheets/common/components/appbar.scss
@@ -21,9 +21,16 @@ c-appbar,
       }
       
       #{$navbar}--right {
+        .dropdown {
+          padding: 2px 0 2px;
+          &:hover {
+            padding: 2px 0 2px 80px;
+          }
+        }
         .dropdown-menu {
           left: auto;
           right: -16px;
+          margin: 0;
         }
       }
       


### PR DESCRIPTION
ドロップダウンメニューがフォーカスを失い消えるのを、修正。

マージンはコンテンツ外なので、その2pxをゆっくりと移動した場合に消えていた。
なのでマージンを消し、下のコンテンツの.dropmenu に少し幅をもたせることで回避した。
また、hover中に真下にカーソルを持っていかなければメニューが消えるのも腹立たしかったので、多少斜めに移動しても消えないようにしました。が、もしも美学に反していた場合は80pxの記述を0pxにしてください。よろしくお願いします。