### PR TITLE
Insert margin after colon between character and cast

### DIFF
--- a/app/views/home/_top_work.html+mobile.slim
+++ b/app/views/home/_top_work.html+mobile.slim
@@ -17,8 +17,9 @@ h3.h2.font-weight-bold.mb-2
     - casts.each do |cast|
       - cache cast do
         li.list-inline-item
-          = cast.character.decorate.name_link
-          | :
+          span.mr-1
+            = cast.character.decorate.name_link
+            | :
           = cast.decorate.local_name_with_old_link
 - staffs = top_work.staffs.major.order(:sort_number)
 - staffs = staffs.select { |s| locale_ja? ? true : s.support_en? }

--- a/app/views/home/_top_work.html.slim
+++ b/app/views/home/_top_work.html.slim
@@ -18,8 +18,9 @@
         - casts.each do |cast|
           - cache cast do
             li.list-inline-item
-              = cast.character.decorate.name_link
-              | :
+              span.mr-1
+                = cast.character.decorate.name_link
+                | :
               = cast.decorate.local_name_with_old_link
     - staffs = top_work.staffs.major.order(:sort_number)
     - staffs = staffs.select { |s| locale_ja? ? true : s.support_en? }

--- a/app/views/works/display_options/_list_detailed.html+mobile.slim
+++ b/app/views/works/display_options/_list_detailed.html+mobile.slim
@@ -62,8 +62,9 @@
                 - casts.first(10).each do |cast|
                   - cache [I18n.locale, cast] do
                     li.list-inline-item
-                      = cast.character.decorate.name_link
-                      | :
+                      span.mr-1
+                        = cast.character.decorate.name_link
+                        | :
                       = cast.decorate.local_name_with_old_link
 
           - cache [I18n.locale, work.staffs.published] do

--- a/app/views/works/display_options/_list_detailed.html.slim
+++ b/app/views/works/display_options/_list_detailed.html.slim
@@ -61,8 +61,9 @@
                 - casts.first(10).each do |cast|
                   - cache [I18n.locale, cast] do
                     li.list-inline-item
-                      = cast.character.decorate.name_link
-                      | :
+                      span.mr-1
+                        = cast.character.decorate.name_link
+                        | :
                       = cast.decorate.local_name_with_old_link
 
           - cache [I18n.locale, work.staffs.published] do


### PR DESCRIPTION
見やすさのため、キャラクターとキャストの間のコロン`:`の直後にマージンを挿入しました。

<img width="338" alt="Screen Shot 2019-03-10 at 12 58 36" src="https://user-images.githubusercontent.com/35105763/54080487-49618900-4334-11e9-9330-71d3cf4a970b.png">
