### PR TITLE
Make caret-down icons clickable

### DIFF
--- a/app/frontend/stylesheets/common/components/channel-selector.scss
+++ b/app/frontend/stylesheets/common/components/channel-selector.scss
@@ -31,7 +31,7 @@
     font-size: 15px;
     position: absolute;
     right: 7px;
-    top: 9px;
+    top: 7px;
     pointer-events: none;
   }
 }

--- a/app/frontend/stylesheets/common/components/channel-selector.scss
+++ b/app/frontend/stylesheets/common/components/channel-selector.scss
@@ -32,5 +32,6 @@
     position: absolute;
     right: 7px;
     top: 9px;
+    pointer-events: none;
   }
 }

--- a/app/frontend/stylesheets/common/components/status-selector.scss
+++ b/app/frontend/stylesheets/common/components/status-selector.scss
@@ -62,6 +62,7 @@
       position: absolute;
       right: 7px;
       top: 11px;
+      pointer-events: none;
     }
   }
 


### PR DESCRIPTION
セレクトボックス中の `caret-down` アイコンをクリックしたときに、セレクトボックスを開くようにしました。
ついでに `/channel/works` でのチャンネル選択セレクトボックスで、アイコンの位置が中央から下にずれていたのを修正しました。

### Before
![before](https://user-images.githubusercontent.com/35105763/56074604-7819c600-5df0-11e9-8bff-205b061b63ca.gif)

### After
![after](https://user-images.githubusercontent.com/35105763/56074607-849e1e80-5df0-11e9-9b40-db4105184061.gif)
