### PR TITLE
GraphQLにエピソード検索追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Layout/AlignParameters:
 Layout/DotPosition:
   EnforcedStyle: trailing
 
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 
 Layout/MultilineOperationIndentation:

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -860,6 +860,29 @@ type Query {
     names: [String!]
     orderBy: CharacterOrder
   ): CharacterConnection
+  searchEpisodes(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+    annictIds: [Int!]
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+    orderBy: EpisodeOrder
+  ): EpisodeConnection
   searchOrganizations(
     """
     Returns the elements in the list that come after the specified cursor.

--- a/app/graphql/types/objects/query.rb
+++ b/app/graphql/types/objects/query.rb
@@ -18,6 +18,11 @@ module Types
         argument :order_by, Types::InputObjects::WorkOrder, required: false
       end
 
+      field :search_episodes, Types::Objects::EpisodeType.connection_type, null: true do
+        argument :annict_ids, [Integer], required: false
+        argument :order_by, Types::InputObjects::EpisodeOrder, required: false
+      end
+
       field :search_people, Types::Objects::PersonType.connection_type, null: true do
         argument :annict_ids, [Integer], required: false
         argument :names, [String], required: false
@@ -49,6 +54,13 @@ module Types
           annict_ids: annict_ids,
           seasons: seasons,
           titles: titles,
+          order_by: order_by
+        ).call
+      end
+
+      def search_episodes(annict_ids: nil, order_by: nil)
+        SearchEpisodesQuery.new(
+          annict_ids: annict_ids,
           order_by: order_by
         ).call
       end

--- a/app/queries/search_episodes_query.rb
+++ b/app/queries/search_episodes_query.rb
@@ -20,12 +20,7 @@ class SearchEpisodesQuery
   private
 
   def from_arguments
-    %i(
-      annict_ids
-    ).each do |arg_name|
-      next if @args[arg_name].nil?
-      @collection = send(arg_name)
-    end
+    apply_filters
 
     if @args[:order_by].present?
       direction = @args[:order_by][:direction]
@@ -39,6 +34,15 @@ class SearchEpisodesQuery
     end
 
     @collection
+  end
+
+  def apply_filters
+    %i(
+      annict_ids
+    ).each do |arg_name|
+      next if @args[arg_name].nil?
+      @collection = send(arg_name)
+    end
   end
 
   def annict_ids

--- a/app/queries/search_episodes_query.rb
+++ b/app/queries/search_episodes_query.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 class SearchEpisodesQuery
-  def initialize(collection = Episode.all, order_by: nil)
+  def initialize(
+    collection = Episode.all,
+    annict_ids: nil,
+    order_by: nil
+  )
     @collection = collection.published
     @args = {
+      annict_ids: annict_ids,
       order_by: order_by
     }
   end
@@ -15,6 +20,13 @@ class SearchEpisodesQuery
   private
 
   def from_arguments
+    %i(
+      annict_ids
+    ).each do |arg_name|
+      next if @args[arg_name].nil?
+      @collection = send(arg_name)
+    end
+
     if @args[:order_by].present?
       direction = @args[:order_by][:direction]
 
@@ -27,5 +39,9 @@ class SearchEpisodesQuery
     end
 
     @collection
+  end
+
+  def annict_ids
+    @collection.where(id: @args[:annict_ids])
   end
 end

--- a/spec/graphql/queries/search_episodes_spec.rb
+++ b/spec/graphql/queries/search_episodes_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+describe "GraphQL API Query" do
+  describe "searchEpisodes" do
+    let!(:work) { create(:work, :with_current_season) }
+    let!(:episode1) { create(:episode, work: work, sort_number: 1) }
+    let!(:episode2) { create(:episode, work: work, sort_number: 3) }
+    let!(:episode3) { create(:episode, work: work, sort_number: 2) }
+
+    context "when `annictIds` argument is specified" do
+      let(:result) do
+        query_string = <<~QUERY
+          query {
+            searchEpisodes(annictIds: [#{episode1.id}]) {
+              edges {
+                node {
+                  annictId
+                  title
+                }
+              }
+            }
+          }
+        QUERY
+
+        res = AnnictSchema.execute(query_string)
+        pp(res) if res["errors"]
+        res
+      end
+
+      it "shows episode" do
+        expect(result.dig("data", "searchEpisodes", "edges")).to match_array([
+          {
+            "node" => {
+              "annictId" => episode1.id,
+              "title" => episode1.title
+            }
+          }
+        ])
+      end
+    end
+
+    context "when `orderBy` argument is specified" do
+      let(:result) do
+        query_string = <<~QUERY
+          query {
+            searchEpisodes(orderBy: { field: SORT_NUMBER, direction: DESC }) {
+              edges {
+                node {
+                  annictId
+                  title
+                  sortNumber
+                }
+              }
+            }
+          }
+        QUERY
+
+        res = AnnictSchema.execute(query_string)
+        pp(res) if res["errors"]
+        res
+      end
+
+      it "shows ordered episodes" do
+        expect(result.dig("data", "searchEpisodes", "edges")).to match_array([
+          {
+            "node" => {
+              "annictId" => episode2.id,
+              "title" => episode2.title,
+              "sortNumber" => 3
+            }
+          },
+          {
+            "node" => {
+              "annictId" => episode3.id,
+              "title" => episode3.title,
+              "sortNumber" => 2
+            }
+          },
+          {
+            "node" => {
+              "annictId" => episode1.id,
+              "title" => episode1.title,
+              "sortNumber" => 1
+            }
+          }
+        ])
+      end
+    end
+
+    context "when `recodes` are fetched" do
+      let!(:record) { create(:episode_record, episode: episode1) }
+      let(:result) do
+        query_string = <<~QUERY
+          query {
+            searchEpisodes(orderBy: { field: SORT_NUMBER, direction: ASC }, first: 1) {
+              edges {
+                node {
+                  annictId
+                  records {
+                    edges {
+                      node {
+                        annictId
+                        comment
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        QUERY
+
+        res = AnnictSchema.execute(query_string)
+        pp(res) if res["errors"]
+        res
+      end
+
+      it "shows records" do
+        expect(result.dig("data", "searchEpisodes", "edges")).to match_array([
+          {
+            "node" => {
+              "annictId" => episode1.id,
+              "records" => {
+                "edges" => [
+                  {
+                    "node" => {
+                      "annictId" => record.id,
+                      "comment" => record.comment
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ])
+      end
+    end
+  end
+end

--- a/spec/graphql/queries/search_episodes_spec.rb
+++ b/spec/graphql/queries/search_episodes_spec.rb
@@ -28,14 +28,16 @@ describe "GraphQL API Query" do
       end
 
       it "shows episode" do
-        expect(result.dig("data", "searchEpisodes", "edges")).to match_array([
-          {
-            "node" => {
-              "annictId" => episode1.id,
-              "title" => episode1.title
+        expect(result.dig("data", "searchEpisodes", "edges")).to match_array(
+          [
+            {
+              "node" => {
+                "annictId" => episode1.id,
+                "title" => episode1.title
+              }
             }
-          }
-        ])
+          ]
+        )
       end
     end
 
@@ -61,29 +63,31 @@ describe "GraphQL API Query" do
       end
 
       it "shows ordered episodes" do
-        expect(result.dig("data", "searchEpisodes", "edges")).to match_array([
-          {
-            "node" => {
-              "annictId" => episode2.id,
-              "title" => episode2.title,
-              "sortNumber" => 3
+        expect(result.dig("data", "searchEpisodes", "edges")).to match_array(
+          [
+            {
+              "node" => {
+                "annictId" => episode2.id,
+                "title" => episode2.title,
+                "sortNumber" => 3
+              }
+            },
+            {
+              "node" => {
+                "annictId" => episode3.id,
+                "title" => episode3.title,
+                "sortNumber" => 2
+              }
+            },
+            {
+              "node" => {
+                "annictId" => episode1.id,
+                "title" => episode1.title,
+                "sortNumber" => 1
+              }
             }
-          },
-          {
-            "node" => {
-              "annictId" => episode3.id,
-              "title" => episode3.title,
-              "sortNumber" => 2
-            }
-          },
-          {
-            "node" => {
-              "annictId" => episode1.id,
-              "title" => episode1.title,
-              "sortNumber" => 1
-            }
-          }
-        ])
+          ]
+        )
       end
     end
 
@@ -116,23 +120,25 @@ describe "GraphQL API Query" do
       end
 
       it "shows records" do
-        expect(result.dig("data", "searchEpisodes", "edges")).to match_array([
-          {
-            "node" => {
-              "annictId" => episode1.id,
-              "records" => {
-                "edges" => [
-                  {
-                    "node" => {
-                      "annictId" => record.id,
-                      "comment" => record.comment
+        expect(result.dig("data", "searchEpisodes", "edges")).to match_array(
+          [
+            {
+              "node" => {
+                "annictId" => episode1.id,
+                "records" => {
+                  "edges" => [
+                    {
+                      "node" => {
+                        "annictId" => record.id,
+                        "comment" => record.comment
+                      }
                     }
-                  }
-                ]
+                  ]
+                }
               }
             }
-          }
-        ])
+          ]
+        )
       end
     end
   end


### PR DESCRIPTION
GraphQLにエピソード情報取得のクエリを追加しました。

rubocop.ymlの変更はrubocopのバージョンアップでリネームされていたようなので追従しました。
ここらへんです: https://github.com/rubocop-hq/rubocop/blob/master/lib/rubocop/config.rb#L60
