### PR TITLE
Update json gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
     jb (0.7.0)
       multi_json
     jmespath (1.4.0)
-    json (2.2.0)
+    json (2.3.0)
     jwt (2.2.1)
     kaminari (1.1.1)
       activesupport (>= 4.1.0)


### PR DESCRIPTION
To avoid following error:

```
/app/vendor/bundle/ruby/2.7.0/gems/json-2.2.0/lib/json/common.rb:156: warning: Using the last argument as keyword parameters is deprecated
```