### PR TITLE
感想の文字数制限を緩める

### DIFF
--- a/app/models/episode_record.rb
+++ b/app/models/episode_record.rb
@@ -80,7 +80,7 @@ class EpisodeRecord < ApplicationRecord
     dependent: :destroy,
     as: :recipient
 
-  validates :body, length: { maximum: 1000 }
+  validates :body, length: { maximum: 1_048_596 }
   validates :rating,
     allow_blank: true,
     numericality: {

--- a/app/models/work_record.rb
+++ b/app/models/work_record.rb
@@ -76,7 +76,7 @@ class WorkRecord < ApplicationRecord
     dependent: :destroy,
     as: :recipient
 
-  validates :body, length: { maximum: 1_500 }
+  validates :body, length: { maximum: 1_048_596 }
 
   scope :with_body, -> { where.not(body: ["", nil]) }
   scope :with_no_body, -> { where(body: ["", nil]) }

--- a/app/views/application/js_templates/_input_words_count.html.slim
+++ b/app/views/application/js_templates/_input_words_count.html.slim
@@ -1,3 +1,3 @@
 script#t-input-words-count type="x-template"
   span.c-input-words-count :class='{ "text-danger": (wordsCount > maxWordsCount) }'
-    | {{ wordsCount }} / {{ maxWordsCount }}
+    | {{ wordsCount }} 文字

--- a/app/views/application/js_templates/_record_word_count.html.slim
+++ b/app/views/application/js_templates/_record_word_count.html.slim
@@ -1,3 +1,3 @@
 script#t-record-word-count type="x-template"
   .c-record-word-count
-    | {{ record.wordCount }} / 1000
+    | {{ record.wordCount }} 文字

--- a/app/views/work_records/_form.html.slim
+++ b/app/views/work_records/_form.html.slim
@@ -8,7 +8,7 @@
     = f.label :body
     c-autosize-textarea.form-control name="work_record[body]" value="#{f.object.body}" placeholder="#{t('messages.work_records.new.write_your_comment')}"
     .text-right.text-muted.small
-      c-input-words-count :max-words-count="1500" :init-words-count="#{f.object.body&.length.presence || 0}" input-name="work_record[body]"
+      c-input-words-count :max-words-count="1048596" :init-words-count="#{f.object.body&.length.presence || 0}" input-name="work_record[body]"
 
   .form-row
     - WorkRecord::STATES.each do |state|

--- a/spec/requests/api/v1/me/records/create_spec.rb
+++ b/spec/requests/api/v1/me/records/create_spec.rb
@@ -68,7 +68,7 @@ describe "POST /v1/me/records" do
     it "returns error" do
       data = {
         episode_id: episode.id,
-        comment: "あぁ^～心がぴょんぴょんするんじゃぁ^～" * 1_000, # too long body
+        comment: "あぁ^～心がぴょんぴょんするんじゃぁ^～" * 52_430, # too long body
         rating: 4.5,
         rating_state: "great",
         access_token: access_token.token
@@ -81,7 +81,7 @@ describe "POST /v1/me/records" do
         errors: [
           {
             type: "invalid_params",
-            message: "感想は1000文字以内で入力してください"
+            message: "感想は1048596文字以内で入力してください"
           }
         ]
       }

--- a/spec/requests/api/v1/me/reviews/create_spec.rb
+++ b/spec/requests/api/v1/me/reviews/create_spec.rb
@@ -63,7 +63,7 @@ describe "POST /v1/me/reviews" do
     it "returns error" do
       data = {
         work_id: work.id,
-        body: "あぁ^～心がぴょんぴょんするんじゃぁ^～" * 1_000, # too long body
+        body: "あぁ^～心がぴょんぴょんするんじゃぁ^～" * 52_430, # too long body
         access_token: access_token.token
       }
       post api("/v1/me/reviews", data)
@@ -74,7 +74,7 @@ describe "POST /v1/me/reviews" do
         errors: [
           {
             type: "invalid_params",
-            message: "本文は1500文字以内で入力してください"
+            message: "本文は1048596文字以内で入力してください"
           }
         ]
       }


### PR DESCRIPTION
https://github.com/annict/annict/pull/2682 で長い感想を省略するようにしたので、長さを制限する必要が無くなった。