### PR TITLE
chore: remove 'your' from the profile statistics header

### DIFF
--- a/config/locales/noun.en.yml
+++ b/config/locales/noun.en.yml
@@ -194,4 +194,4 @@ en:
     work_image: Work image
     work: Work
     works: Works
-    your_statistics: Your Statistics
+    your_statistics: Statistics


### PR DESCRIPTION
The same string is displayed on your own profile and other user profiles, where you're not viewing your own statistics but their statistics.