### PR TITLE
記録の評価部分の見た目を調整

### DIFF
--- a/app/components/collapses/deprecated_ratings_collapse_component.rb
+++ b/app/components/collapses/deprecated_ratings_collapse_component.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Collapses
+  class DeprecatedRatingsCollapseComponent < ApplicationV6Component
+    def initialize(view_context, record:, class_name: "")
+      super view_context
+      @record = record
+      @deprecated_animation_rating = @record.deprecated_animation_rating
+      @deprecated_music_rating = @record.deprecated_music_rating
+      @deprecated_story_rating = @record.deprecated_story_rating
+      @deprecated_character_rating = @record.deprecated_character_rating
+      @class_name = class_name
+    end
+
+    def render
+      return "" unless @record.deprecated_rating_exists?
+
+      build_html do |h|
+        h.tag :span, class: "u-cursor-pointer #{@class_name}", data_bs_toggle: "collapse", href: "##{collapse_dom_id}" do
+          h.tag :i, class: "far fa-ellipsis-h"
+        end
+
+        h.tag :div, class: "collapse p-2", id: collapse_dom_id do
+          h.tag :div, class: "gap-1 vstack" do
+            if @deprecated_animation_rating
+              h.tag :div, class: "gx-3 row", style: "width: 250px;" do
+                h.tag :div, class: "col-6" do
+                  h.tag :span, class: "me-1 small text-muted" do
+                    h.text t("noun.animation")
+                  end
+                end
+
+                h.tag :div, class: "col-6" do
+                  h.html Labels::RatingLabelComponent.new(view_context, rating: @deprecated_animation_rating).render
+                end
+              end
+            end
+
+            if @deprecated_music_rating
+              h.tag :div, class: "gx-3 row", style: "width: 250px;" do
+                h.tag :div, class: "col-6" do
+                  h.tag :span, class: "me-1 small text-muted" do
+                    h.text t("noun.music")
+                  end
+                end
+
+                h.tag :div, class: "col-6" do
+                  h.html Labels::RatingLabelComponent.new(view_context, rating: @deprecated_music_rating).render
+                end
+              end
+            end
+
+            if @deprecated_story_rating
+              h.tag :div, class: "gx-3 row", style: "width: 250px;" do
+                h.tag :div, class: "col-6" do
+                  h.tag :span, class: "me-1 small text-muted" do
+                    h.text t("noun.story")
+                  end
+                end
+
+                h.tag :div, class: "col-6" do
+                  h.html Labels::RatingLabelComponent.new(view_context, rating: @deprecated_story_rating).render
+                end
+              end
+            end
+
+            if @deprecated_character_rating
+              h.tag :div, class: "gx-3 row", style: "width: 250px;" do
+                h.tag :div, class: "col-6" do
+                  h.tag :span, class: "me-1 small text-muted" do
+                    h.text t("noun.character")
+                  end
+                end
+
+                h.tag :div, class: "col-6" do
+                  h.html Labels::RatingLabelComponent.new(view_context, rating: @deprecated_character_rating).render
+                end
+              end
+            end
+          end
+
+          h.tag :div, class: "mt-2 text-muted u-very-small" do
+            h.tag :i, class: "far fa-info-circle me-1"
+            h.text t("messages._components.deprecated_ratings_collapse.hint")
+          end
+        end
+      end
+    end
+
+    private
+
+    def collapse_dom_id
+      "deprecated-rating-labels-#{@record.id}"
+    end
+  end
+end

--- a/app/components/contents/record_content_component.rb
+++ b/app/components/contents/record_content_component.rb
@@ -20,6 +20,10 @@ module Contents
                   h.html Labels::RatingLabelComponent.new(view_context, rating: @record.rating, advanced_rating: @record.advanced_rating, class_name: "mb-1").render
                 end
 
+                if @record.deprecated_rating_exists?
+                  h.html Collapses::DeprecatedRatingsCollapseComponent.new(view_context, record: @record, class_name: "ms-2 text-muted").render
+                end
+
                 h.html BodyV6Component.new(view_context, content: @record.comment, format: :markdown, height: 300).render
               end
             })

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -65,6 +65,26 @@ class Record < ApplicationRecord
     episode_record? ? episode_record.rating : nil
   end
 
+  def deprecated_animation_rating
+    anime_record&.rating_animation_state
+  end
+
+  def deprecated_character_rating
+    anime_record&.rating_character_state
+  end
+
+  def deprecated_music_rating
+    anime_record&.rating_music_state
+  end
+
+  def deprecated_story_rating
+    anime_record&.rating_story_state
+  end
+
+  def deprecated_rating_exists?
+    deprecated_animation_rating || deprecated_music_rating || deprecated_story_rating || deprecated_character_rating
+  end
+
   def comment
     episode_record? ? episode_record.body : anime_record&.body
   end

--- a/config/locales/messages.en.yml
+++ b/config/locales/messages.en.yml
@@ -32,6 +32,8 @@ en:
         hide_ads_html: You can hide ads by becoming <a href="/supporters">Annict Supporters</a>
       body:
         view_full_text: View Full Text
+      deprecated_ratings_collapse:
+        hint: This 4 ratings are an old feature that existed in Annict.
       favorite_button:
         add_to_favorites: Add to Favorites
         added_to_favorites: Added to Favorites

--- a/config/locales/messages.ja.yml
+++ b/config/locales/messages.ja.yml
@@ -32,6 +32,8 @@ ja:
         hide_ads_html: <a href="/supporters">Annictサポーター</a>になると広告を非表示にできます
       body:
         view_full_text: 全文読む
+      deprecated_ratings_collapse:
+        hint: 以前作品の記録に設定できた4項目の評価を表示しています
       favorite_button:
         add_to_favorites: お気に入りに登録
         added_to_favorites: 登録済み


### PR DESCRIPTION
作品の記録で設定できたアニメーション、音楽、ストーリー、キャラクターの4項目を表示するように。