### PR TITLE
作品に関連するデータの編集履歴に作品情報を表示するように

### DIFF
--- a/app/views/db/activities/_activity_child_resources_action.ja.html.slim
+++ b/app/views/db/activities/_activity_child_resources_action.ja.html.slim
@@ -5,11 +5,19 @@ span.me-1
   | が
 
 span.me-1
+  = activity.trackable.work.db_detail_link
+| の
+
+span.me-1
+  = activity.trackable.class.model_name.human
+
+span.me-1
   = activity.trackable.db_detail_link
 
 span.me-1
-  = "の#{activity.trackable.class.model_name.human} (##{activity.trackable.id}) を"
+  = "(##{activity.trackable.id})"
 
+| を
 - action = activity.action.split(".")[1]
 - if action == "create"
   | 登録しました


### PR DESCRIPTION
データ自体のタイトルだけだとどの作品の話だかピンとこない/わからないことがあるので、 child_resource_actionな編集履歴では作品の名前/リンクも表示するようにしてみました。

|before|after|
|---|---|
|<img width="400" alt="image" src="https://user-images.githubusercontent.com/6533808/185807681-c4946a6b-579e-4dc9-926a-cf41770f507f.png">|<img width="450" alt="image" src="https://user-images.githubusercontent.com/6533808/185807723-a781fa9c-3452-46f1-81fe-e65814a2cd60.png">|