### PR TITLE
Deplicate duplicated `ActivityEdge#node`

### DIFF
--- a/app/graphql/beta/edges/activity_edge.rb
+++ b/app/graphql/beta/edges/activity_edge.rb
@@ -8,7 +8,8 @@ module Beta
       field :annict_id, Integer, null: false
       field :user, Beta::Types::Objects::UserType, null: false
       field :action, Beta::Types::Enums::ActivityAction, null: false
-      field :node, Beta::Types::Unions::ActivityItem, null: true
+      field :node, Beta::Types::Unions::ActivityItem, null: true, deprecation_reason: "Use `item` instead."
+      field :item, Beta::Types::Unions::ActivityItem, null: true, resolver_method: :node
 
       def annict_id
         activity = object.node

--- a/app/graphql/beta/edges/activity_edge.rb
+++ b/app/graphql/beta/edges/activity_edge.rb
@@ -8,7 +8,7 @@ module Beta
       field :annict_id, Integer, null: false
       field :user, Beta::Types::Objects::UserType, null: false
       field :action, Beta::Types::Enums::ActivityAction, null: false
-      field :node, Beta::Types::Unions::ActivityItem, null: true, deprecation_reason: "Use `item` instead."
+      field :node, Beta::Types::Unions::ActivityItem, "Deprecated: Use `item` instead.", null: true, deprecation_reason: "Use `item` instead."
       field :item, Beta::Types::Unions::ActivityItem, null: true, resolver_method: :node
 
       def annict_id

--- a/app/graphql/beta/edges/series_work_edge.rb
+++ b/app/graphql/beta/edges/series_work_edge.rb
@@ -8,7 +8,8 @@ module Beta
 
       field :summary, String, null: true
       field :summary_en, String, null: true
-      field :node, Beta::Types::Objects::WorkType, null: false
+      field :node, Beta::Types::Objects::WorkType, null: false, deprecation_reason: "Use `item` instead."
+      field :item, Beta::Types::Objects::WorkType, null: false, resolver_method: :node
 
       def summary
         object.node.summary

--- a/app/graphql/beta/edges/series_work_edge.rb
+++ b/app/graphql/beta/edges/series_work_edge.rb
@@ -8,7 +8,7 @@ module Beta
 
       field :summary, String, null: true
       field :summary_en, String, null: true
-      field :node, Beta::Types::Objects::WorkType, null: false, deprecation_reason: "Use `item` instead."
+      field :node, Beta::Types::Objects::WorkType, "Deprecated: Use `item` instead.", null: false, deprecation_reason: "Use `item` instead."
       field :item, Beta::Types::Objects::WorkType, null: false, resolver_method: :node
 
       def summary

--- a/app/graphql/beta/schema.graphql
+++ b/app/graphql/beta/schema.graphql
@@ -45,7 +45,8 @@ type ActivityEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  node: ActivityItem
+  item: ActivityItem
+  node: ActivityItem @deprecated(reason: "Use `item` instead.")
   user: User!
 }
 
@@ -1310,7 +1311,8 @@ type SeriesWorkEdge {
   A cursor for use in pagination.
   """
   cursor: String!
-  node: Work!
+  item: Work!
+  node: Work! @deprecated(reason: "Use `item` instead.")
   summary: String
   summaryEn: String
 }

--- a/app/graphql/beta/schema.graphql
+++ b/app/graphql/beta/schema.graphql
@@ -46,6 +46,10 @@ type ActivityEdge {
   """
   cursor: String!
   item: ActivityItem
+
+  """
+  Deprecated: Use `item` instead.
+  """
   node: ActivityItem @deprecated(reason: "Use `item` instead.")
   user: User!
 }
@@ -1312,6 +1316,10 @@ type SeriesWorkEdge {
   """
   cursor: String!
   item: Work!
+
+  """
+  Deprecated: Use `item` instead.
+  """
   node: Work! @deprecated(reason: "Use `item` instead.")
   summary: String
   summaryEn: String


### PR DESCRIPTION
`graphql` gem 1.13.0 から同名のフィールドが複数定義されたときの挙動が変わった。

- 1.13.0未満: 最初に定義されたフィールドは後から定義されたフィールドによって上書きされる
- 1.13.0以降: `GraphQL::Schema::DuplicateNamesError` が発生する

1.13.0以降にアップデートするため、まずは重複しているフィールドを非推奨にする。

ref: https://github.com/rmosolgo/graphql-ruby/blob/e94569f51606f3635d8beb042d9f9c769dc9ae49/CHANGELOG.md#new-features-17