### PR TITLE
キャラクタ名の省略表示を追加

### DIFF
--- a/app/views/people/_grid.html.erb
+++ b/app/views/people/_grid.html.erb
@@ -17,7 +17,7 @@
               <div class="small text-truncate">
                 <%= link_to work.local_title, work_path(work_id: work.id), class: "text-body" %>
 
-                <div class="text-muted">
+                <div class="text-muted text-truncate">
                   <% description = resources.map { |resource| root_resource.grid_description(resource) }.join(", ") %>
                   <%= description.html_safe %>
                 </div>


### PR DESCRIPTION
## 概要
#3912 のフォローアップです。

## 対応内容
- 上部の作品名と同様に、省略表示のクラスを適用しました。
　
## 再現ページ
- https://annict.com/people/19913

## 画面
|修正前|修正後|
|---|---|
|<img width="391" alt="スクリーンショット 2023-03-17 20 26 00" src="https://user-images.githubusercontent.com/39184410/225892664-26da99bd-04da-4bf4-ad5e-d86c07c65127.png">|<img width="386" alt="スクリーンショット 2023-03-17 20 24 17" src="https://user-images.githubusercontent.com/39184410/225892704-df19e464-7d49-4d32-8cb9-c4eb291a2a96.png">|


ご確認をお願いいたします。