### PR TITLE
コレクションの「新規作成」ボタンがダークテーマ時に白くなってしまう問題を修正

### DIFF
--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -19,7 +19,7 @@
       <div class="grid" style="--bs-gap: 1rem; grid-auto-rows: 1fr;">
         <% if current_user && current_user == @user %>
           <div class="g-col-12 g-col-md-6 g-col-lg-4">
-            <div class="bg-body border card h-100 u-border-3 u-border-card">
+            <div class="border card h-100 u-border-3 u-border-card">
               <%= link_to new_collection_path, class: "card-body d-flex text-body text-center" do %>
                 <div class="align-self-center w-100">
                   <i class="display-6 far fa-plus"></i>


### PR DESCRIPTION
## 説明

コレクションタブの「新規作成」ボタンに`bg-body`クラスが指定されてしまっているため白くなってしまっていました。

## 修正内容

`bg-body`クラスを削除しました。

## スクリーンショット

- ローカル環境ではなく、本番環境でDev toolsからクラスを削除して確認したものですのでご容赦ください。

||変更前|変更後|
|:--:|:--:|:--:|
|light|![スクリーンショット 2023-03-30 194111](https://user-images.githubusercontent.com/24271196/228814974-af2eb77d-097a-4cc4-8a1e-6f089a9a81a6.png)|![スクリーンショット 2023-03-30 194922](https://user-images.githubusercontent.com/24271196/228815031-9a36acf8-745c-41f6-af3d-94d61458d964.png)|
|dark|![スクリーンショット 2023-03-30 194135](https://user-images.githubusercontent.com/24271196/228814861-1b39df66-627c-42a5-a956-175ffb1f6ec0.png)|![スクリーンショット 2023-03-30 194938](https://user-images.githubusercontent.com/24271196/228814911-9e70fa39-2cb9-4c9f-b6cd-84cc198d8030.png)|
