### PR TITLE
Temporarily hide the find friends page

### DIFF
--- a/app/components/deprecated/sidebars/main_sidebar_component.rb
+++ b/app/components/deprecated/sidebars/main_sidebar_component.rb
@@ -169,7 +169,7 @@ module Deprecated::Sidebars
 
             h.tag :ul, class: "list-unstyled px-3" do
               [
-                [view_context.friend_list_path, "search", t("head.title.friends.index")],
+                # [view_context.friend_list_path, "search", t("head.title.friends.index")],
                 [view_context.channel_list_path, "tv-retro", t("head.title.channels.index")],
                 [view_context.settings_profile_path, "cog", t("noun.settings")],
                 [view_context.faq_path, "question-circle", t("noun.faq")]


### PR DESCRIPTION
- https://github.com/annict/annict/pull/3924 でTwitter連携機能を削除することになった
- 今の友達を探すページはTwitterでフォローしている人を見つける機能がほぼ全てなので、Twitter連携が削除されるとほとんど意味が無くなってしまう
- https://github.com/annict/annict/issues/3807 などの対応をするときに復活させたい