### PR TITLE
OAuth アプリケーションの編集画面で現在のスコープの値が表示されていないバグを修正

### DIFF
--- a/app/views/oauth/applications/_form.html.slim
+++ b/app/views/oauth/applications/_form.html.slim
@@ -21,7 +21,7 @@
   .mb-3.row
     = f.label :scopes, class: "col-2 col-form-label"
     .col-10
-      = select_tag "oauth_application[scopes]", options_for_select([[t("messages.oauth.applications.read_only"), "read"], [t("messages.oauth.applications.read_write"), "read write"]]), class: "form-select"
+      = select_tag "oauth_application[scopes]", options_for_select([[t("messages.oauth.applications.read_only"), "read"], [t("messages.oauth.applications.read_write"), "read write"]], application.scopes), class: "form-select"
       = doorkeeper_errors_for application, :scopes
 
   .mb-3.row.mb-0


### PR DESCRIPTION
- OAuth アプリケーションの編集画面のバグを修正しました
  - https://annict.com/oauth/applications/xxx/edit
- この画面に現在のスコープの値が表示されておらず、常に「読み込み専用」(read) が選択されるようになっていました
  - `option` 要素に `selected` 属性が付いていないため
- [options_for_select | Railsドキュメント](https://railsdoc.com/page/options_for_select) の呼び出しに現在選択されている要素として `application.scopes` を渡すようにしました