### PR TITLE
メールをResendから送る

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,4 +114,5 @@ end
 
 group :production do
   gem "lograge"
+  gem "resend"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -458,6 +458,8 @@ GEM
     regexp_parser (2.6.0)
     request_store (1.5.1)
       rack (>= 1.4)
+    resend (0.9.0)
+      httparty (>= 0.19.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -663,6 +665,7 @@ DEPENDENCIES
   rails_autolink
   ransack
   redis
+  resend
   rspec-mocks
   rspec-rails
   sentry-rails

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,14 +87,7 @@ Rails.application.configure do
     protocol: "https://",
     host: ENV.fetch("ANNICT_HOST")
   }
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    address: ENV.fetch("ANNICT_SMTP_HOST"),
-    port: ENV.fetch("ANNICT_SMTP_PORT"),
-    user_name: ENV.fetch("ANNICT_SMTP_USERNAME"),
-    password: ENV.fetch("ANNICT_SMTP_PASSWORD"),
-    authentication: :plain
-  }
+  config.action_mailer.delivery_method = :resend
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/initializers/resend.rb
+++ b/config/initializers/resend.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+if Rails.env.production?
+  Resend.api_key = ENV["ANNICT_RESEND_API_KEY"]
+end


### PR DESCRIPTION
Fix: ANN-21

DMARC対応のついでにSendGridから[Resend](https://resend.com/)に乗り換える