### PR TITLE
use-corepack-in-test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,9 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16.14.2
-
+      - name: Setup Yarn
+        run: |
+          corepack enable yarn
       - name: Run `yarn install`
         run: |
           yarn install

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "node": "16.14.2",
     "yarn": "1.22.21"
   },
+  "packageManager": "yarn@1.22.21",
   "scripts": {
     "build:css": "sass app/assets/stylesheets/application.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds",


### PR DESCRIPTION
CIの持ってるyarnと指定してるyarnのバージョンが違うのでcorepackで解決する
もしかしたらenginesのyarnのバージョン固定消したほうがいいのかもしれない
