### PR TITLE
リリース年が未定の場合に0と表示される箇所を修正

### DIFF
--- a/app/views/people/_grid.html.erb
+++ b/app/views/people/_grid.html.erb
@@ -3,7 +3,7 @@
     <% resource_years.each do |year| %>
       <div class="col-12">
         <h3 class="text-center mb-3">
-          <%= year %>
+          <%= year == 0 ? "時期未定" : year %>
         </h3>
 
         <div class="g-3 row">


### PR DESCRIPTION
ref: https://github.com/annict/annict/issues/407

- Issueに上がっていたリリース年が未定の場合に0年と表示される箇所を修正しました
- Railsもプライベートなコントリビュートも初心者なのでもっと良いやり方があれば修正するので仰ってください