### PR TITLE
シリーズ作品一覧の順番で開始日のソートを含める(#4011)

### DIFF
--- a/app/models/series_work.rb
+++ b/app/models/series_work.rb
@@ -47,6 +47,7 @@ class SeriesWork < ApplicationRecord
     joins(:work)
       .order("works.season_year #{sort_type}")
       .order("works.season_name #{sort_type}")
+      .order("works.started_on #{sort_type}")
   end
 
   def to_diffable_hash

--- a/app/views/related_works/index.html.erb
+++ b/app/views/related_works/index.html.erb
@@ -11,7 +11,7 @@
 
 <% if @series_list.present? %>
   <% @series_list.each do |series| %>
-    <% series_works = series.series_works %>
+    <% series_works = series.series_works.sort_season.order(:id) %>
 
     <div class="container mt-5">
       <h2 class="fw-bold h3 mb-3">

--- a/spec/models/series_work_spec.rb
+++ b/spec/models/series_work_spec.rb
@@ -1,32 +1,52 @@
 # typed: false
 # frozen_string_literal: true
 
+def create_work(season_year: 2010, season_name: 'spring', started_on: '2010-04-11')
+  create(:work,
+         season_year:,
+         season_name:,
+         started_on: Date.parse(started_on))
+end
+
 describe SeriesWork, type: :model do
   describe '.sort_season' do
-    context 'when same season_year and different started_on' do
+    let(:series) { create(:series) }
+
+    context 'differ in season_year, season_name, and started_on' do
+      let(:work_earier_started_on) { create_work(started_on: '2010-04-01') }
+      let(:work_later_started_on) { create_work(started_on: '2010-04-21') }
+      let(:work_earier_season_year) { create_work(season_year: 2009) }
+      let(:work_earier_season_name) { create_work(season_name: 'winter', started_on: '2010-01-21') }
+
       before do
-        series = create(:series)
-
-        common_attributes = { season_year: 2010, season_name: 'spring' }
-        @work_started_on_first = create(:work,
-                                        **common_attributes,
-                                        started_on: Date.parse('2010-01-01'))
-        @work_started_on_last = create(:work,
-                                       **common_attributes,
-                                       started_on: Date.parse('2010-12-01'))
-        @work_started_on_second = create(:work,
-                                         **common_attributes,
-                                         started_on: Date.parse('2010-06-01'))
-
-        create(:series_work, series:, work: @work_started_on_first)
-        create(:series_work, series:, work: @work_started_on_last)
-        create(:series_work, series:, work: @work_started_on_second)
+        create(:series_work, series:, work: work_later_started_on)
+        create(:series_work, series:, work: work_earier_started_on)
+        create(:series_work, series:, work: work_earier_season_year)
+        create(:series_work, series:, work: work_earier_season_name)
       end
 
-      it 'sorts SeriesWork by started_on column in ascending order', :aggregate_failures do
-        expect(SeriesWork.sort_season.first.work).to eq(@work_started_on_first)
-        expect(SeriesWork.sort_season.second.work).to eq(@work_started_on_second)
-        expect(SeriesWork.sort_season.last.work).to eq(@work_started_on_last)
+      it 'sorts SeriesWork by season_year, then season_name, and then started_on in ascending order',
+         :aggregate_failures do
+        expect(SeriesWork.sort_season[0].work).to eq(work_earier_season_year)
+        expect(SeriesWork.sort_season[1].work).to eq(work_earier_season_name)
+        expect(SeriesWork.sort_season[2].work).to eq(work_earier_started_on)
+        expect(SeriesWork.sort_season[3].work).to eq(work_later_started_on)
+      end
+    end
+
+    context 'when one work has a nil season_year but an earlier started_on date' do
+      let(:work_with_season_year_nil) { create_work(season_year: nil, started_on: '2009-04-01') }
+      let(:work_with_season_year_exists) { create_work(season_year: 2010, started_on: '2010-04-01') }
+
+      before do
+        create(:series_work, series:, work: work_with_season_year_nil)
+        create(:series_work, series:, work: work_with_season_year_exists)
+      end
+
+      it 'places the work with a valid season_year before the work with a nil season_year, regardless of started_on date',
+         :aggregate_failures do
+        expect(SeriesWork.sort_season[0].work).to eq(work_with_season_year_exists)
+        expect(SeriesWork.sort_season[1].work).to eq(work_with_season_year_nil)
       end
     end
   end

--- a/spec/models/series_work_spec.rb
+++ b/spec/models/series_work_spec.rb
@@ -1,0 +1,33 @@
+# typed: false
+# frozen_string_literal: true
+
+describe SeriesWork, type: :model do
+  describe '.sort_season' do
+    context 'when same season_year and different started_on' do
+      before do
+        series = create(:series)
+
+        common_attributes = { season_year: 2010, season_name: 'spring' }
+        @work_started_on_first = create(:work,
+                                        **common_attributes,
+                                        started_on: Date.parse('2010-01-01'))
+        @work_started_on_last = create(:work,
+                                       **common_attributes,
+                                       started_on: Date.parse('2010-12-01'))
+        @work_started_on_second = create(:work,
+                                         **common_attributes,
+                                         started_on: Date.parse('2010-06-01'))
+
+        create(:series_work, series:, work: @work_started_on_first)
+        create(:series_work, series:, work: @work_started_on_last)
+        create(:series_work, series:, work: @work_started_on_second)
+      end
+
+      it 'sorts SeriesWork by started_on column in ascending order', :aggregate_failures do
+        expect(SeriesWork.sort_season.first.work).to eq(@work_started_on_first)
+        expect(SeriesWork.sort_season.second.work).to eq(@work_started_on_second)
+        expect(SeriesWork.sort_season.last.work).to eq(@work_started_on_last)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Issue: #4011 

## 改修内容
- `SeriesWork.sort_season`のソート処理を変更しました
- 既存は(リリース時期 → 季節 → id)の順番でソートされていたのを(リリース時期 → 季節 → 開始日 → id)という順番で並び替えるようにしました
- `sort_season`メソッドは使われている箇所が多く影響範囲がやや広いため、ここに改修を入れるか迷いました
- ただ、開始日をソートから除外したいユースケースが自分は想像できなかったこと、「開始日をアニメシリーズのシーズンによる並び替えは開始日も考慮する」という風に一貫性を持たせた方が良いのではと思い取り敢えず`sort_season`メソッドに改修を入れたという形になります
- RailsやRuby歴が浅く、コントリビュートも今回が初めてなので、考慮不足や不備があれば仰って頂きたく思います


## 改修によるクエリの変更
`SeriesWork.sort_season`で発行されるクエリの変更点

```diff
SELECT
    "series_works".* FROM "series_works"
INNER JOIN
    "works" ON "works"."id" = "series_works"."work_id"
ORDER BY
    works.season_year ASC,
    works.season_name ASC,
+   works.started_on ASC
```

## 補足
すみません、テストが長くなりrubocop違反になりました。。。

```
Offenses:

spec/models/series_work_spec.rb:11:1: C: Metrics/BlockLength: Block has too many lines. [35/25]
describe SeriesWork, type: :model do ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/models/series_work_spec.rb:12:3: C: Metrics/BlockLength: Block has too many lines. [33/25]
  describe '.sort_season' do ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/models/series_work_spec.rb:46:121: C: Layout/LineLength: Line is too long. [122/120]
      it 'places the work with a valid season_year before the work with a nil season_year, regardless of started_on date',
                                                                                                                        ^^

1 file inspected, 3 offenses detected
```