### PR TITLE
一度に多くのエピソードを視聴済みにした時のプロフィールページの表示速度改善(#3996)

### DIFF
--- a/app/models/activity_group.rb
+++ b/app/models/activity_group.rb
@@ -73,8 +73,10 @@ class ActivityGroup < ApplicationRecord
       when "Status"
         all_statuses.find_all { |s| activities.pluck(:trackable_id).include?(s.id) }
       when "EpisodeRecord"
-        episode_records = all_episode_records.find_all { |er| activities.pluck(:trackable_id).include?(er.id) }
-        all_records.find_all { |r| episode_records.pluck(:record_id).include?(r.id) }
+        trackable_ids = activities.pluck(:trackable_id)
+        episode_records = all_episode_records.where(id: trackable_ids)
+        episode_record_ids = episode_records.pluck(:record_id)
+        all_records.where(id: episode_record_ids)
       when "AnimeRecord", "WorkRecord"
         work_records = all_work_records.find_all { |ar| activities.pluck(:trackable_id).include?(ar.id) }
         all_records.find_all { |r| work_records.pluck(:record_id).include?(r.id) }


### PR DESCRIPTION
ref: https://github.com/annict/annict/issues/3996

## 表示速度の変化(ローカルで確認)
- 6000レコードの場合
  - 修正前: 16.036 seconds
  - 修正後: 0.48 seconds

確認環境
- OS: Mac 15.0.1(Apple Silicon)
- 実行環境: Macターミナル
- メモリ: 16 GB

## 修正概要
6000エピソードを視聴済みにしたと仮定します。
その状況の時、修正前の以下のコードでは、以下のように計12000回のループ処理が行われていました。

1. `all_episode_records.find_all { |er| activities.pluck(:trackable_id).include?(er.id) }`では、6000回ループされる
1. `all_records.find_all { |r| episode_records.pluck(:record_id).include?(r.id) }`でも6000回ループされる

↓修正前のコード
```ruby
 episode_records = all_episode_records.find_all { |er| activities.pluck(:trackable_id).include?(er.id) }
 all_records.find_all { |r| episode_records.pluck(:record_id).include?(r.id) }
```

そのため、修正案として以下のようにwhere句によって、ループ処理を行わない形でデータをフィルターすることを提案させて頂きます。

**ただ、この修正案ではwhere句によるクエリが増えるため、コストが増える可能性もございます。**

現時点では、こちらの修正案が最も変更点が把握しやすいものであると思われるため、この形で修正の提案をさせて頂いた形になります。

### 状況毎の表示時間の推移
以下はエピソードの記録数を調整して、表示時間を計測したものです。
今回の修正ではエピソードの視聴記録数が少ない時に表示速度が遅くなることが懸念されているため、どの程度遅くなりうるのかを計測しました。

結論としては、今回の修正では、**各作品3エピソードを記録した時に約0.2秒遅くなる**傾向があることが分かりました。

↓ 視聴記録数の調整は、以下のエピソード作成処理のループ数で行う
<details>
  <summary>データ作成スクリプト</summary>

```ruby
# frozen_string_literal: true

50.times do |entire_loop|
  ActiveRecord::Base.transaction do
    # Workを作成
    work = Work.create!(
      title: "sample work #{entire_loop}",
      title_kana: 'さんぷるたいとる',
      media: :tv,
      official_site_url: 'http://example.com',
      wikipedia_url: 'http://wikipedia.org',
      synopsis: 'サンプルあらすじ',
      synopsis_source: 'ソースはなし',
      twitter_username: 'Okunichiyou',
      twitter_hashtag: 'nichiyoubi',
      mal_anime_id: 12_345,
      released_at: Date.parse('2019-12-09'),
      released_at_about: '2019年',
      season_year: 2019,
      season_name: 'spring'
    )
  
    # Episodeを作成　ここの数を調整してエピソードの視聴数を調整する
    episodes = (1..12).map do |i|
      { work_id: work.id, number: "第#{i}話", title: "タイトル#{i}" }
    end
    inserted_ids = Episode.insert_all(episodes).rows.flatten
  
    # Userを取得
    user = User.first
  
    # 作品の視聴ステータスを作成
    status = user.statuses.new(work:, kind: 'watched')
    status.save!
    status.save_library_entry!
    activity_group = user.create_or_last_activity_group!(status)
    user.activities.create!(itemable: status, activity_group:)
  
    # エピソードの視聴履歴を作成
    inserted_ids.each_with_index do |ep_id, i|
      ep = Episode.find_by_id(ep_id)
      ep_reco = ep.build_episode_record(
        user:,
        watched_at: Time.zone.now
      )
      ep_reco.save!
      ag = user.create_or_last_activity_group!(ep_reco)
      user.activities.create!(itemable: ep_reco, activity_group: ag)
  
      library_entry = user.library_entries.where(work:).first_or_create!
      library_entry.append_episode!(ep)
  
      puts "エピソード: #{i + 1}"
    end
  end
end


```
</details>

#### 50作品(各作品3エピソード)に視聴履歴のアクテビティを付与した場合
- 修正前:  0.267 seconds
- 修正後:  0.429 seconds

#### 50作品(各作品12エピソード)に視聴履歴のアクテビティを付与した場合
- 修正前: 0.428 seconds
- 修正後: 0.343 seconds

#### 50作品(各作品24エピソード)に視聴履歴のアクテビティを付与した場合
- 修正前: 0.608 seconds
- 修正後: 0.405 seconds

## 調査内容
そもそも見当違いな調査をしていて、誤った方向性の修正提案をしているかもしれないので、調査過程についても共有させて頂きます。

### データの作成
<details>
  <summary>データ作成スクリプト</summary>

```ruby
# frozen_string_literal: true

ActiveRecord::Base.transaction do
  # Workを作成
  work = Work.create!(
    title: 'sample work3',
    title_kana: 'さんぷるたいとる',
    media: :tv,
    official_site_url: 'http://example.com',
    wikipedia_url: 'http://wikipedia.org',
    synopsis: 'サンプルあらすじ',
    synopsis_source: 'ソースはなし',
    twitter_username: 'Okunichiyou',
    twitter_hashtag: 'nichiyoubi',
    mal_anime_id: 12_345,
    released_at: Date.parse('2019-12-09'),
    released_at_about: '2019年',
    season_year: 2019,
    season_name: 'spring'
  )

  # Episodeを作成
  episodes = (1..6000).map do |i|
    { work_id: work.id, number: "第#{i}話", title: "タイトル#{i}" }
  end
  inserted_ids = Episode.insert_all(episodes).rows.flatten

  # Userを取得
  user = User.first

  # 作品の視聴ステータスを作成
  status = user.statuses.new(work:, kind: 'watched')
  status.save!
  status.save_library_entry!
  activity_group = user.create_or_last_activity_group!(status)
  user.activities.create!(itemable: status, activity_group:)

  # エピソードの視聴履歴を作成
  inserted_ids.each_with_index do |ep_id, i|
    ep = Episode.find_by_id(ep_id)
    ep_reco = ep.build_episode_record(
      user:,
      watched_at: Time.zone.now
    )
    ep_reco.save!
    ag = user.create_or_last_activity_group!(ep_reco)
    user.activities.create!(itemable: ep_reco, activity_group: ag)

    library_entry = user.library_entries.where(work:).first_or_create!
    library_entry.append_episode!(ep)

    puts "エピソード: #{i + 1}"
  end
end

```
</details>


### 処理速度の計測
https://github.com/Okunichiyou/annict/commit/3a5dc0e380d1716e86c5a087bd6319fc7e3e42f5#diff-d3c4b3f41072daa416f1920511e9b2e26caea8c5cec0a14cb9508589a4dafa47R23 でログを仕込んで計測しました。

6000レコードの場合は、以下のようにepisode_recordsやall_recordsをフィルターする処理に時間がかかっていることが分かったため、今回修正した箇所の処理について遅い原因を考えていきました。

```
% grep -a 'For Measure' log/development.log
[For Measure] start: ProfilesController#show
[For Measure] start: @activity_groups.flat_map.with_prelude
[For Measure] Finding episode_records took: 5.803 seconds
[For Measure] Finding records from episode_records took: 9.962 seconds
[For Measure] Finding statuses took: 0.007 seconds
[For Measure] work_ids took: 16.017 seconds
[For Measure] ProfilesController#show took: 16.036 seconds
```