### PR TITLE
季節に`all`を指定した際に作品を正しく取得する (#4119)

### DIFF
--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -67,10 +67,9 @@ class Season
   end
 
   def work_conditions
-    {
-      season_year: @year,
-      season_name: all? ? nil : name_value
-    }
+    conditions = {season_year: @year}
+    conditions[:season_name] = name_value unless all?
+    conditions
   end
 
   def all?


### PR DESCRIPTION
## issue

resolve #4119

## 修正内容

作品を取得する際に、季節に `YYYY-all` を指定すると、本来その年のすべての作品を取得するはずが、季節が指定されていない作品のみが取得されてしまうバグを修正しました。
バグは、`season_name`が`"all"`の際に`nil`になる作品を検索していたことによるものだと思われます。

修正後、ローカル環境のWeb版で問題が解決したことを確認しています。

## 備考

issueでは、API(`/v1/works`, `/v1/works/me`)についてのみ触れられていましたが、web版でも同様の問題が再現していました。(model周りの問題だったため、当然といえば当然です)