### PR TITLE
Fix `Rack::QueryParser::QueryLimitError`

### DIFF
--- a/app/models/episode_record.rb
+++ b/app/models/episode_record.rb
@@ -31,7 +31,7 @@ class EpisodeRecord < ApplicationRecord
     dependent: :destroy,
     as: :recipient
 
-  validates :body, length: {maximum: 1_048_596}
+  validates :body, length: {maximum: Record::MAX_BODY_LENGTH}
   validates :rating,
     allow_blank: true,
     numericality: {

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -5,6 +5,7 @@ class Record < ApplicationRecord
   include SoftDeletable
   include Likeable
 
+  MAX_BODY_LENGTH = 1_048_596
   RATING_STATES = %i[bad average good great].freeze
 
   counter_culture :user

--- a/app/models/work_record.rb
+++ b/app/models/work_record.rb
@@ -43,7 +43,7 @@ class WorkRecord < ApplicationRecord
     dependent: :destroy,
     as: :recipient
 
-  validates :body, length: {maximum: 1_048_596}
+  validates :body, length: {maximum: Record::MAX_BODY_LENGTH}
 
   scope :with_body, -> { where.not(body: ["", nil]) }
   scope :with_no_body, -> { where(body: ["", nil]) }

--- a/spec/requests/api/v1/me/records/create_spec.rb
+++ b/spec/requests/api/v1/me/records/create_spec.rb
@@ -69,7 +69,7 @@ describe "POST /v1/me/records" do
     it "returns error" do
       data = {
         episode_id: episode.id,
-        comment: "あぁ^～心がぴょんぴょんするんじゃぁ^～" * 52_430, # too long body
+        comment: "a" * (Record::MAX_BODY_LENGTH + 1), # too long body
         rating: 4.5,
         rating_state: "great",
         access_token: access_token.token

--- a/spec/requests/api/v1/me/reviews/create_spec.rb
+++ b/spec/requests/api/v1/me/reviews/create_spec.rb
@@ -64,7 +64,7 @@ describe "POST /v1/me/reviews" do
     it "returns error" do
       data = {
         work_id: work.id,
-        body: "あぁ^～心がぴょんぴょんするんじゃぁ^～" * 52_430, # too long body
+        body: "a" * (Record::MAX_BODY_LENGTH + 1), # too long body
         access_token: access_token.token
       }
       post api("/v1/me/reviews", data)


### PR DESCRIPTION
https://github.com/annict/annict/pull/4197 でRackのバージョンを上げたところ↓のようなエラーが起きるようになったので、その対応です。

```
ActionController::BadRequest:
Invalid query parameters: total query size (8808349) exceeds limit (4194304)
# ./spec/requests/api/v1/me/records/create_spec.rb:77:in `block (3 levels) in <top (required)>'
# ------------------
# --- Caused by: ---
# Rack::QueryParser::QueryLimitError:
#   total query size (8808349) exceeds limit (4194304)
#   ./spec/requests/api/v1/me/records/create_spec.rb:77:in `block (3 levels) in <top (required)>'
```