### PR TITLE
作品のシーズンソート時のページネーションで発生する重複・欠落を修正

### DIFF
--- a/app/models/work.rb
+++ b/app/models/work.rb
@@ -140,7 +140,7 @@ class Work < ApplicationRecord
   }
 
   scope :order_by_season, ->(type = :asc) {
-    order(season_year: type, season_name: type)
+    order(season_year: type, season_name: type, id: :asc)
   }
 
   scope :season_from, -> (season) {


### PR DESCRIPTION
## issue
resolve #4247 

## 概要
**修正前の問題**
シーズンでソートした際、同一シーズン内の作品順序が一意に定まっていませんでした。そのため、ページネーション時に作品の重複や欠落が発生していました。

**修正内容**
シーズンソート時に`id`をタイブレーカーとして追加し、同一シーズン内でも一意の順序を保証するよう修正しました。

## 動作確認
ローカル環境で以下の通り動作確認を行いました。

**修正前の動作 (問題のある状態)**
<details><summary>ページ間で作品が重複していることを確認</summary>

```sh
$ curl "http://api.annict.test:3000/v1/me/works?sort_season=desc&per_page=8&page=1" -s | jq ".works[].title"
"サンプルアニメ 2025-spring 02"
"サンプルアニメ 2025-spring 04"
"サンプルアニメ 2025-spring 05"
"サンプルアニメ 2025-spring 07"
"サンプルアニメ 2025-spring 06"
"サンプルアニメ 2025-spring 08"
"サンプルアニメ 2025-spring 09"
"サンプルアニメ 2025-spring 03" # 重複

$ curl "http://api.annict.test:3000/v1/me/works?sort_season=desc&per_page=8&page=2" -s | jq ".works[].title"
"サンプルアニメ 2025-spring 15"
"サンプルアニメ 2025-spring 13"
"サンプルアニメ 2025-spring 17"
"サンプルアニメ 2025-spring 14"
"サンプルアニメ 2025-spring 20"
"サンプルアニメ 2025-spring 19"
"サンプルアニメ 2025-spring 10"
"サンプルアニメ 2025-spring 03" # 重複
```
</details>

**修正後の動作 (正常な状態)**
```sh
$ curl "http://api.annict.test:3000/v1/works?sort_season=desc&per_page=8&page=1" -s | jq ".works[].title"
"サンプルアニメ 2025-spring 01"
"サンプルアニメ 2025-spring 02"
"サンプルアニメ 2025-spring 03"
"サンプルアニメ 2025-spring 04"
"サンプルアニメ 2025-spring 05"
"サンプルアニメ 2025-spring 06"
"サンプルアニメ 2025-spring 07"
"サンプルアニメ 2025-spring 08"

$ curl "http://api.annict.test:3000/v1/works?sort_season=desc&per_page=8&page=2" -s | jq ".works[].title"
"サンプルアニメ 2025-spring 09"
"サンプルアニメ 2025-spring 10"
"サンプルアニメ 2025-spring 11"
"サンプルアニメ 2025-spring 12"
"サンプルアニメ 2025-spring 13"
"サンプルアニメ 2025-spring 14"
"サンプルアニメ 2025-spring 15"
"サンプルアニメ 2025-spring 16"
```

修正後は重複や欠落がなく、連続した順序で作品が取得できています。