### PR TITLE
forkされたリポジトリからPRを送った時にもCIが実行されるようにした

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,6 +1,8 @@
 name: Lint and test
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   zeitwerk:


### PR DESCRIPTION
#4269 や #4278 でPRを送った時にCIが実行されないのが気になったのでPRでもCIが実行されるように修正しました。

意図的なものかどうかは分からないですが、PR送る側からすると自分のパッチでCIが実行されていた方が安心感があるのでなおしました。