### PR TITLE
非公開でシリーズ作品が登録されている時にそのシリーズが関連作品として出ていたのを修正

### DIFF
--- a/app/controllers/related_works_controller.rb
+++ b/app/controllers/related_works_controller.rb
@@ -13,6 +13,7 @@ class RelatedWorksController < ApplicationV6Controller
       .series_list
       .eager_load(series_works: {work: :work_image})
       .only_kept
+      .merge(SeriesWork.only_kept)
       .order("works.season_year ASC")
       .order("works.season_name ASC")
       .order(:created_at)

--- a/spec/requests/works/related_works_spec.rb
+++ b/spec/requests/works/related_works_spec.rb
@@ -141,4 +141,15 @@ RSpec.describe "GET /works/:work_id/related_works", type: :request do
     expect(response.body).to include(published_on_series_work.title)
     expect(response.body).not_to include(unpublished_on_series_work.title)
   end
+
+  it "非公開でシリーズ作品が登録されている時にシリーズ自体表示されないこと" do
+    series = create(:series)
+    work = create(:work)
+    create(:series_work, series: series, work: work, unpublished_at: Time.current)
+
+    get "/works/#{work.id}/related_works"
+
+    expect(response.status).to eq(200)
+    expect(response.body).not_to include("#{series.name} #{I18n.t("noun.series")}")
+  end
 end


### PR DESCRIPTION
# 背景
[アニメ「カードファイト!! ヴァンガード Divinez 幻真星戦編」の関連作品 | Annict](https://annict.com/works/16624/related_works) で、明らかに関係ないはずの「ラブライブ！ School Idol Project シリーズ」が表示されています。

<img width="1132" height="661" alt="image" src="https://github.com/user-attachments/assets/67c377ad-1469-4763-aad7-9abe7e9026d0" />

----

[ラブライブ！ School Idol Projectのシリーズ編集画面](https://annict.com/db/series/119/series_works) で見たところ該当作品は非公開にされていました。

<img width="1106" height="446" alt="image" src="https://github.com/user-attachments/assets/052c9876-6919-46dc-abe2-f9312cfa6779" />

多分編集者の誰かが間違えて登録した後に非公開にしたと思うんですが、非公開状態なのにそのシリーズが関連作品に出ていると見栄えが悪いので表示しないようにしました。

# ローカルでの動作確認内容
ローカルでも似たような状態を作って修正されていることを確認済みです。

## 使ったデータ
<img width="956" height="352" alt="image" src="https://github.com/user-attachments/assets/6b11179f-2f7c-4012-9257-90e5629f0a0a" />

<img width="937" height="333" alt="image" src="https://github.com/user-attachments/assets/9fd5d7a9-b97f-4cdf-8aaf-23ae349dbaa6" />


## Before
<img width="804" height="580" alt="image" src="https://github.com/user-attachments/assets/cd0b8813-e6c2-4c82-8178-95e21ce2024e" />

## After
<img width="773" height="475" alt="image" src="https://github.com/user-attachments/assets/806a4a88-45bb-4b9e-8dbd-ed424407945b" />
