### PR TITLE
feat: dアニメストア ニコニコ支店において、シリーズが存在しない作品を動画IDで登録できるようにする

### DIFF
--- a/app/helpers/vod_helper.rb
+++ b/app/helpers/vod_helper.rb
@@ -11,7 +11,11 @@ module VodHelper
     when Channel::D_ANIME_STORE_ID
       "https://animestore.docomo.ne.jp/animestore/ci_pc?workId=#{code}"
     when Channel::D_ANIME_STORE_NICONICO_ID
-      "https://www.nicovideo.jp/series/#{code}"
+      if code.start_with? "so"
+        "https://www.nicovideo.jp/watch/#{code}"
+      else
+        "https://www.nicovideo.jp/series/#{code}"
+      end
     when Channel::NICONICO_CHANNEL_ID
       "https://ch.nicovideo.jp/#{code}"
     when Channel::NETFLIX_ID

--- a/app/helpers/vod_helper.rb
+++ b/app/helpers/vod_helper.rb
@@ -24,4 +24,6 @@ module VodHelper
       "https://abema.tv/video/title/#{code}"
     end
   end
+
+  module_function :vod_title_url
 end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -39,28 +39,7 @@ class Program < ApplicationRecord
   def vod_title_url
     return "" if vod_title_code.blank?
 
-    case channel_id
-    when Channel::AMAZON_VIDEO_ID
-      "https://www.amazon.co.jp/dp/#{vod_title_code}"
-    when Channel::BANDAI_CHANNEL_ID
-      "https://www.b-ch.com/ttl/index.php?ttl_c=#{vod_title_code}"
-    when Channel::D_ANIME_STORE_ID
-      "https://animestore.docomo.ne.jp/animestore/ci_pc?workId=#{vod_title_code}"
-    when Channel::D_ANIME_STORE_NICONICO_ID
-      if vod_title_code.start_with? "so"
-        "https://www.nicovideo.jp/watch/#{vod_title_code}"
-      else
-        "https://www.nicovideo.jp/series/#{vod_title_code}"
-      end
-    when Channel::NICONICO_CHANNEL_ID
-      "https://ch.nicovideo.jp/#{vod_title_code}"
-    when Channel::NETFLIX_ID
-      "https://www.netflix.com/title/#{vod_title_code}"
-    when Channel::ABEMA_VIDEO_ID
-      "https://abema.tv/video/title/#{vod_title_code}"
-    else
-      ""
-    end
+    VodHelper.vod_title_url(channel_id, vod_title_code) or ""
   end
 
   def slot_by_episode(episode)

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -47,7 +47,11 @@ class Program < ApplicationRecord
     when Channel::D_ANIME_STORE_ID
       "https://animestore.docomo.ne.jp/animestore/ci_pc?workId=#{vod_title_code}"
     when Channel::D_ANIME_STORE_NICONICO_ID
-      "https://www.nicovideo.jp/series/#{vod_title_code}"
+      if vod_title_code.start_with? "so"
+        "https://www.nicovideo.jp/watch/#{vod_title_code}"
+      else
+        "https://www.nicovideo.jp/series/#{vod_title_code}"
+      end
     when Channel::NICONICO_CHANNEL_ID
       "https://ch.nicovideo.jp/#{vod_title_code}"
     when Channel::NETFLIX_ID

--- a/app/views/db/programs/_sidebar_edit.html.erb
+++ b/app/views/db/programs/_sidebar_edit.html.erb
@@ -44,6 +44,8 @@
       </td>
       <td>
         <a href="https://www.nicovideo.jp/series/62802" target="_blank" rel="noopener">62802</a>
+        シリーズがない作品 (映画、OVAなど) の場合は
+        <a href="https://www.nicovideo.jp/watch/so37528628" target="_blank" rel="noopener">so37528628</a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
作品IDがsoから始まっていた場合、シリーズページではなく視聴ページのURLを返すようにしています。

ニコニコ動画において、近年のチャンネル動画はすべて動画IDに `so` プレフィックスを使っているため、これで十分なはずです。

ついでに同じ処理が二箇所にあったので統合していますが、余計だったらrevertするなり cherry-pick するなりしていただければと思います。

