### PR TITLE
Fix dead link to FAQ in footer section

### DIFF
--- a/rails/app/controllers/faqs_controller.rb
+++ b/rails/app/controllers/faqs_controller.rb
@@ -3,6 +3,6 @@
 
 class FaqsController < ApplicationV6Controller
   def show
-    redirect_to "https://github.com/annict/annict/blob/main/docs/faq.md"
+    redirect_to "https://github.com/annict/annict/blob/main/rails/docs/faq.md"
   end
 end

--- a/rails/spec/requests/faqs/show_spec.rb
+++ b/rails/spec/requests/faqs/show_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe "GET /faq", type: :request do
   it "GitHubに置いてあるドキュメントにリダイレクトすること" do
     get "/faq"
 
-    expect(response).to redirect_to("https://github.com/annict/annict/blob/main/docs/faq.md")
+    expect(response).to redirect_to("https://github.com/annict/annict/blob/main/rails/docs/faq.md")
   end
 end


### PR DESCRIPTION
This PR fixes the wrong redirect from `/faq` to the annict FAQ page in footer section.

```diff
- https://github.com/annict/annict/blob/main/docs/faq.md
+ https://github.com/annict/annict/blob/main/rails/docs/faq.md
```

<img width="679" height="306" alt="image" src="https://github.com/user-attachments/assets/995d80ee-0201-4e13-93df-dcea6dede2e6" />
