### PR TITLE
StripeWebhookEventRepositoryの作成

### DIFF
--- a/go/internal/repository/stripe_webhook_event.go
+++ b/go/internal/repository/stripe_webhook_event.go
@@ -1,0 +1,77 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/annict/annict/go/internal/model"
+	"github.com/annict/annict/go/internal/query"
+)
+
+// StripeWebhookEventRepository はStripe Webhookイベントのリポジトリです
+type StripeWebhookEventRepository struct {
+	queries *query.Queries
+}
+
+// NewStripeWebhookEventRepository は新しいStripeWebhookEventRepositoryを作成します
+func NewStripeWebhookEventRepository(queries *query.Queries) *StripeWebhookEventRepository {
+	return &StripeWebhookEventRepository{queries: queries}
+}
+
+// Create は新しいWebhookイベントを作成します
+func (r *StripeWebhookEventRepository) Create(ctx context.Context, params query.CreateStripeWebhookEventParams) (query.StripeWebhookEvent, error) {
+	return r.queries.CreateStripeWebhookEvent(ctx, params)
+}
+
+// GetByStripeEventID はStripe Event IDでWebhookイベントを取得します
+func (r *StripeWebhookEventRepository) GetByStripeEventID(ctx context.Context, stripeEventID string) (query.StripeWebhookEvent, error) {
+	return r.queries.GetStripeWebhookEventByStripeEventID(ctx, stripeEventID)
+}
+
+// UpdateStatus はWebhookイベントのステータスを更新します
+func (r *StripeWebhookEventRepository) UpdateStatus(ctx context.Context, params query.UpdateStripeWebhookEventStatusParams) error {
+	return r.queries.UpdateStripeWebhookEventStatus(ctx, params)
+}
+
+// MarkAsProcessed はWebhookイベントを処理完了としてマークします
+func (r *StripeWebhookEventRepository) MarkAsProcessed(ctx context.Context, id int64) error {
+	return r.queries.UpdateStripeWebhookEventStatus(ctx, query.UpdateStripeWebhookEventStatusParams{
+		ID:           id,
+		Status:       model.WebhookEventStatusProcessed.String(),
+		ErrorMessage: sql.NullString{},
+		ProcessedAt:  sql.NullTime{Time: time.Now(), Valid: true},
+	})
+}
+
+// MarkAsFailed はWebhookイベントを処理失敗としてマークします
+func (r *StripeWebhookEventRepository) MarkAsFailed(ctx context.Context, id int64, errorMessage string) error {
+	return r.queries.UpdateStripeWebhookEventStatus(ctx, query.UpdateStripeWebhookEventStatusParams{
+		ID:           id,
+		Status:       model.WebhookEventStatusFailed.String(),
+		ErrorMessage: sql.NullString{String: errorMessage, Valid: true},
+		ProcessedAt:  sql.NullTime{Time: time.Now(), Valid: true},
+	})
+}
+
+// MarkAsSkipped はWebhookイベントを処理スキップとしてマークします
+func (r *StripeWebhookEventRepository) MarkAsSkipped(ctx context.Context, id int64) error {
+	return r.queries.UpdateStripeWebhookEventStatus(ctx, query.UpdateStripeWebhookEventStatusParams{
+		ID:           id,
+		Status:       model.WebhookEventStatusSkipped.String(),
+		ErrorMessage: sql.NullString{},
+		ProcessedAt:  sql.NullTime{Time: time.Now(), Valid: true},
+	})
+}
+
+// Exists はStripe Event IDで既にイベントが存在するかを確認します（冪等性チェック用）
+func (r *StripeWebhookEventRepository) Exists(ctx context.Context, stripeEventID string) (bool, error) {
+	_, err := r.queries.GetStripeWebhookEventByStripeEventID(ctx, stripeEventID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}

--- a/go/internal/repository/stripe_webhook_event_test.go
+++ b/go/internal/repository/stripe_webhook_event_test.go
@@ -1,0 +1,264 @@
+package repository_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/annict/annict/go/internal/model"
+	"github.com/annict/annict/go/internal/query"
+	"github.com/annict/annict/go/internal/repository"
+	"github.com/annict/annict/go/internal/testutil"
+)
+
+// TestStripeWebhookEventRepository_Create は新しいWebhookイベントを作成できることをテスト
+func TestStripeWebhookEventRepository_Create(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewStripeWebhookEventRepository(queries)
+
+	now := time.Now()
+	params := query.CreateStripeWebhookEventParams{
+		StripeEventID:   "evt_test_create",
+		StripeEventType: "customer.subscription.created",
+		StripePayload:   json.RawMessage(`{"id": "evt_test_create", "type": "customer.subscription.created"}`),
+		Status:          model.WebhookEventStatusPending.String(),
+		ReceivedAt:      now,
+	}
+
+	event, err := repo.Create(context.Background(), params)
+	if err != nil {
+		t.Fatalf("Webhookイベントの作成に失敗: %v", err)
+	}
+
+	if event.ID == 0 {
+		t.Error("IDが設定されていません")
+	}
+	if event.StripeEventID != params.StripeEventID {
+		t.Errorf("StripeEventIDが一致しません: got %s, want %s", event.StripeEventID, params.StripeEventID)
+	}
+	if event.StripeEventType != params.StripeEventType {
+		t.Errorf("StripeEventTypeが一致しません: got %s, want %s", event.StripeEventType, params.StripeEventType)
+	}
+	if event.Status != model.WebhookEventStatusPending.String() {
+		t.Errorf("Statusが一致しません: got %s, want %s", event.Status, model.WebhookEventStatusPending.String())
+	}
+}
+
+// TestStripeWebhookEventRepository_GetByStripeEventID はStripeイベントIDで取得できることをテスト
+func TestStripeWebhookEventRepository_GetByStripeEventID(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewStripeWebhookEventRepository(queries)
+
+	// テストデータを作成
+	testutil.NewStripeWebhookEventBuilder(t, tx).
+		WithStripeEventID("evt_unique_event").
+		Build()
+
+	// StripeイベントIDで取得
+	event, err := repo.GetByStripeEventID(context.Background(), "evt_unique_event")
+	if err != nil {
+		t.Fatalf("Webhookイベントの取得に失敗: %v", err)
+	}
+
+	if event.StripeEventID != "evt_unique_event" {
+		t.Errorf("StripeEventIDが一致しません: got %s, want %s", event.StripeEventID, "evt_unique_event")
+	}
+}
+
+// TestStripeWebhookEventRepository_GetByStripeEventID_NotFound は存在しないイベントIDの場合エラーが返ることをテスト
+func TestStripeWebhookEventRepository_GetByStripeEventID_NotFound(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewStripeWebhookEventRepository(queries)
+
+	_, err := repo.GetByStripeEventID(context.Background(), "evt_nonexistent")
+	if err == nil {
+		t.Error("存在しないイベントIDでエラーが返されるべきです")
+	}
+	if err != sql.ErrNoRows {
+		t.Errorf("予期しないエラー: got %v, want %v", err, sql.ErrNoRows)
+	}
+}
+
+// TestStripeWebhookEventRepository_UpdateStatus はステータスを更新できることをテスト
+func TestStripeWebhookEventRepository_UpdateStatus(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewStripeWebhookEventRepository(queries)
+
+	// テストデータを作成
+	eventID := testutil.NewStripeWebhookEventBuilder(t, tx).
+		WithStripeEventID("evt_update_status").
+		WithStatus(model.WebhookEventStatusPending.String()).
+		Build()
+
+	// ステータスを更新
+	now := time.Now()
+	err := repo.UpdateStatus(context.Background(), query.UpdateStripeWebhookEventStatusParams{
+		ID:           eventID,
+		Status:       model.WebhookEventStatusProcessed.String(),
+		ErrorMessage: sql.NullString{},
+		ProcessedAt:  sql.NullTime{Time: now, Valid: true},
+	})
+	if err != nil {
+		t.Fatalf("ステータス更新に失敗: %v", err)
+	}
+
+	// 更新後のデータを確認
+	event, err := repo.GetByStripeEventID(context.Background(), "evt_update_status")
+	if err != nil {
+		t.Fatalf("更新後のイベント取得に失敗: %v", err)
+	}
+
+	if event.Status != model.WebhookEventStatusProcessed.String() {
+		t.Errorf("Statusが更新されていません: got %s, want %s", event.Status, model.WebhookEventStatusProcessed.String())
+	}
+	if !event.ProcessedAt.Valid {
+		t.Error("ProcessedAtが設定されていません")
+	}
+}
+
+// TestStripeWebhookEventRepository_MarkAsProcessed は処理完了としてマークできることをテスト
+func TestStripeWebhookEventRepository_MarkAsProcessed(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewStripeWebhookEventRepository(queries)
+
+	// テストデータを作成
+	eventID := testutil.NewStripeWebhookEventBuilder(t, tx).
+		WithStripeEventID("evt_mark_processed").
+		Build()
+
+	// 処理完了としてマーク
+	err := repo.MarkAsProcessed(context.Background(), eventID)
+	if err != nil {
+		t.Fatalf("MarkAsProcessedに失敗: %v", err)
+	}
+
+	// 更新後のデータを確認
+	event, err := repo.GetByStripeEventID(context.Background(), "evt_mark_processed")
+	if err != nil {
+		t.Fatalf("更新後のイベント取得に失敗: %v", err)
+	}
+
+	if event.Status != model.WebhookEventStatusProcessed.String() {
+		t.Errorf("Statusが更新されていません: got %s, want %s", event.Status, model.WebhookEventStatusProcessed.String())
+	}
+	if !event.ProcessedAt.Valid {
+		t.Error("ProcessedAtが設定されていません")
+	}
+}
+
+// TestStripeWebhookEventRepository_MarkAsFailed は処理失敗としてマークできることをテスト
+func TestStripeWebhookEventRepository_MarkAsFailed(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewStripeWebhookEventRepository(queries)
+
+	// テストデータを作成
+	eventID := testutil.NewStripeWebhookEventBuilder(t, tx).
+		WithStripeEventID("evt_mark_failed").
+		Build()
+
+	// 処理失敗としてマーク
+	errorMsg := "処理中にエラーが発生しました"
+	err := repo.MarkAsFailed(context.Background(), eventID, errorMsg)
+	if err != nil {
+		t.Fatalf("MarkAsFailedに失敗: %v", err)
+	}
+
+	// 更新後のデータを確認
+	event, err := repo.GetByStripeEventID(context.Background(), "evt_mark_failed")
+	if err != nil {
+		t.Fatalf("更新後のイベント取得に失敗: %v", err)
+	}
+
+	if event.Status != model.WebhookEventStatusFailed.String() {
+		t.Errorf("Statusが更新されていません: got %s, want %s", event.Status, model.WebhookEventStatusFailed.String())
+	}
+	if !event.ErrorMessage.Valid {
+		t.Error("ErrorMessageが設定されていません")
+	}
+	if event.ErrorMessage.String != errorMsg {
+		t.Errorf("ErrorMessageが一致しません: got %s, want %s", event.ErrorMessage.String, errorMsg)
+	}
+	if !event.ProcessedAt.Valid {
+		t.Error("ProcessedAtが設定されていません")
+	}
+}
+
+// TestStripeWebhookEventRepository_MarkAsSkipped は処理スキップとしてマークできることをテスト
+func TestStripeWebhookEventRepository_MarkAsSkipped(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewStripeWebhookEventRepository(queries)
+
+	// テストデータを作成
+	eventID := testutil.NewStripeWebhookEventBuilder(t, tx).
+		WithStripeEventID("evt_mark_skipped").
+		Build()
+
+	// 処理スキップとしてマーク
+	err := repo.MarkAsSkipped(context.Background(), eventID)
+	if err != nil {
+		t.Fatalf("MarkAsSkippedに失敗: %v", err)
+	}
+
+	// 更新後のデータを確認
+	event, err := repo.GetByStripeEventID(context.Background(), "evt_mark_skipped")
+	if err != nil {
+		t.Fatalf("更新後のイベント取得に失敗: %v", err)
+	}
+
+	if event.Status != model.WebhookEventStatusSkipped.String() {
+		t.Errorf("Statusが更新されていません: got %s, want %s", event.Status, model.WebhookEventStatusSkipped.String())
+	}
+	if !event.ProcessedAt.Valid {
+		t.Error("ProcessedAtが設定されていません")
+	}
+}
+
+// TestStripeWebhookEventRepository_Exists はイベントの存在確認ができることをテスト
+func TestStripeWebhookEventRepository_Exists(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewStripeWebhookEventRepository(queries)
+
+	// テストデータを作成
+	testutil.NewStripeWebhookEventBuilder(t, tx).
+		WithStripeEventID("evt_exists_check").
+		Build()
+
+	testCases := []struct {
+		name          string
+		stripeEventID string
+		expected      bool
+	}{
+		{
+			name:          "存在するイベントID",
+			stripeEventID: "evt_exists_check",
+			expected:      true,
+		},
+		{
+			name:          "存在しないイベントID",
+			stripeEventID: "evt_nonexistent",
+			expected:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			exists, err := repo.Exists(context.Background(), tc.stripeEventID)
+			if err != nil {
+				t.Fatalf("Exists()でエラーが発生: %v", err)
+			}
+			if exists != tc.expected {
+				t.Errorf("Exists() = %v, want %v", exists, tc.expected)
+			}
+		})
+	}
+}

--- a/go/internal/testutil/fixtures.go
+++ b/go/internal/testutil/fixtures.go
@@ -628,3 +628,108 @@ func CreateTestStripeSubscriberWithStatus(t *testing.T, tx *sql.Tx, status strin
 	t.Helper()
 	return NewStripeSubscriberBuilder(t, tx).WithStripeStatus(status).Build()
 }
+
+// StripeWebhookEventBuilder はStripe Webhookイベントテストデータのビルダー
+type StripeWebhookEventBuilder struct {
+	tx              *sql.Tx
+	t               *testing.T
+	stripeEventID   string
+	stripeEventType string
+	stripePayload   string
+	status          string
+	receivedAt      time.Time
+}
+
+// NewStripeWebhookEventBuilder は新しいStripeWebhookEventBuilderを作成します
+func NewStripeWebhookEventBuilder(t *testing.T, tx *sql.Tx) *StripeWebhookEventBuilder {
+	uniqueID := uuid.New().String()[:8]
+
+	return &StripeWebhookEventBuilder{
+		tx:              tx,
+		t:               t,
+		stripeEventID:   fmt.Sprintf("evt_test_%s", uniqueID),
+		stripeEventType: "customer.subscription.created",
+		stripePayload:   `{"id": "evt_test", "type": "customer.subscription.created"}`,
+		status:          "pending",
+		receivedAt:      time.Now(),
+	}
+}
+
+// WithStripeEventID はStripeイベントIDを設定します
+func (b *StripeWebhookEventBuilder) WithStripeEventID(id string) *StripeWebhookEventBuilder {
+	b.stripeEventID = id
+	return b
+}
+
+// WithStripeEventType はStripeイベントタイプを設定します
+func (b *StripeWebhookEventBuilder) WithStripeEventType(eventType string) *StripeWebhookEventBuilder {
+	b.stripeEventType = eventType
+	return b
+}
+
+// WithStripePayload はStripeペイロードを設定します
+func (b *StripeWebhookEventBuilder) WithStripePayload(payload string) *StripeWebhookEventBuilder {
+	b.stripePayload = payload
+	return b
+}
+
+// WithStatus はステータスを設定します
+func (b *StripeWebhookEventBuilder) WithStatus(status string) *StripeWebhookEventBuilder {
+	b.status = status
+	return b
+}
+
+// WithReceivedAt は受信日時を設定します
+func (b *StripeWebhookEventBuilder) WithReceivedAt(receivedAt time.Time) *StripeWebhookEventBuilder {
+	b.receivedAt = receivedAt
+	return b
+}
+
+// Build はテスト用のStripe Webhookイベントデータをデータベースに作成します
+func (b *StripeWebhookEventBuilder) Build() int64 {
+	b.t.Helper()
+
+	query := `
+		INSERT INTO stripe_webhook_events (
+			stripe_event_id,
+			stripe_event_type,
+			stripe_payload,
+			status,
+			received_at,
+			created_at,
+			updated_at
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7
+		) RETURNING id
+	`
+
+	var id int64
+	err := b.tx.QueryRow(
+		query,
+		b.stripeEventID,
+		b.stripeEventType,
+		b.stripePayload,
+		b.status,
+		b.receivedAt,
+		time.Now(),
+		time.Now(),
+	).Scan(&id)
+
+	if err != nil {
+		b.t.Fatalf("Stripe Webhookイベントデータの作成に失敗しました: %v", err)
+	}
+
+	return id
+}
+
+// CreateTestStripeWebhookEvent は簡単にテスト用Stripe Webhookイベントを作成するヘルパー関数
+func CreateTestStripeWebhookEvent(t *testing.T, tx *sql.Tx) int64 {
+	t.Helper()
+	return NewStripeWebhookEventBuilder(t, tx).Build()
+}
+
+// CreateTestStripeWebhookEventWithStatus は指定ステータスでテスト用Stripe Webhookイベントを作成するヘルパー関数
+func CreateTestStripeWebhookEventWithStatus(t *testing.T, tx *sql.Tx, status string) int64 {
+	t.Helper()
+	return NewStripeWebhookEventBuilder(t, tx).WithStatus(status).Build()
+}


### PR DESCRIPTION
- internal/repository/stripe_webhook_event.go を作成
  - Create, GetByStripeEventID, UpdateStatus メソッドの実装
  - MarkAsProcessed, MarkAsFailed, MarkAsSkipped ヘルパーメソッドの追加
  - Exists メソッド（冪等性チェック用）の追加
- internal/repository/stripe_webhook_event_test.go でテストを実装
- internal/testutil/fixtures.go に StripeWebhookEventBuilder を追加