### PR TITLE
usersテーブルにstripe_subscriber_idカラムを追加

### DIFF
--- a/go/db/migrations/20260111101233_add_stripe_subscriber_id_to_users.sql
+++ b/go/db/migrations/20260111101233_add_stripe_subscriber_id_to_users.sql
@@ -1,0 +1,14 @@
+-- migrate:up
+ALTER TABLE users ADD COLUMN stripe_subscriber_id BIGINT;
+
+CREATE INDEX idx_users_stripe_subscriber_id ON users(stripe_subscriber_id);
+
+ALTER TABLE users ADD CONSTRAINT fk_users_stripe_subscriber
+    FOREIGN KEY (stripe_subscriber_id) REFERENCES stripe_subscribers(id);
+
+-- migrate:down
+ALTER TABLE users DROP CONSTRAINT fk_users_stripe_subscriber;
+
+DROP INDEX idx_users_stripe_subscriber_id;
+
+ALTER TABLE users DROP COLUMN stripe_subscriber_id;

--- a/go/db/schema.sql
+++ b/go/db/schema.sql
@@ -2869,7 +2869,8 @@ CREATE TABLE public.users (
     on_hold_works_count integer DEFAULT 0 NOT NULL,
     dropped_works_count integer DEFAULT 0 NOT NULL,
     following_count integer DEFAULT 0 NOT NULL,
-    followers_count integer DEFAULT 0 NOT NULL
+    followers_count integer DEFAULT 0 NOT NULL,
+    stripe_subscriber_id bigint
 );
 
 
@@ -4675,6 +4676,13 @@ CREATE UNIQUE INDEX idx_stripe_webhook_events_stripe_event_id ON public.stripe_w
 --
 
 CREATE INDEX idx_stripe_webhook_events_stripe_event_type ON public.stripe_webhook_events USING btree (stripe_event_type);
+
+
+--
+-- Name: idx_users_stripe_subscriber_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_users_stripe_subscriber_id ON public.users USING btree (stripe_subscriber_id);
 
 
 --
@@ -7274,6 +7282,14 @@ ALTER TABLE ONLY public.episode_records
 
 
 --
+-- Name: users fk_users_stripe_subscriber; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT fk_users_stripe_subscriber FOREIGN KEY (stripe_subscriber_id) REFERENCES public.stripe_subscribers(id);
+
+
+--
 -- Name: follows follows_following_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -7721,4 +7737,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20251112061948'),
     ('20251113173140'),
     ('20260111083416'),
-    ('20260111084224');
+    ('20260111084224'),
+    ('20260111101233');

--- a/go/internal/query/models.go
+++ b/go/internal/query/models.go
@@ -1087,6 +1087,7 @@ type User struct {
 	DroppedWorksCount          int32          `db:"dropped_works_count"`
 	FollowingCount             int32          `db:"following_count"`
 	FollowersCount             int32          `db:"followers_count"`
+	StripeSubscriberID         sql.NullInt64  `db:"stripe_subscriber_id"`
 }
 
 type UserlandCategory struct {

--- a/go/internal/query/querier.go
+++ b/go/internal/query/querier.go
@@ -6,6 +6,7 @@ package query
 
 import (
 	"context"
+	"database/sql"
 	"time"
 )
 
@@ -53,6 +54,7 @@ type Querier interface {
 	GetUserByEmailForSignIn(ctx context.Context, lower string) (GetUserByEmailForSignInRow, error)
 	GetUserByEmailOrUsername(ctx context.Context, lower string) (GetUserByEmailOrUsernameRow, error)
 	GetUserByID(ctx context.Context, id int64) (GetUserByIDRow, error)
+	GetUserByStripeSubscriberID(ctx context.Context, stripeSubscriberID sql.NullInt64) (GetUserByStripeSubscriberIDRow, error)
 	GetUserByUsername(ctx context.Context, lower string) (GetUserByUsernameRow, error)
 	GetValidSignInCode(ctx context.Context, userID int64) (SignInCode, error)
 	GetValidSignUpCode(ctx context.Context, email string) (SignUpCode, error)
@@ -73,6 +75,7 @@ type Querier interface {
 	UpdateStripeSubscriberStatus(ctx context.Context, arg UpdateStripeSubscriberStatusParams) error
 	UpdateStripeWebhookEventStatus(ctx context.Context, arg UpdateStripeWebhookEventStatusParams) error
 	UpdateUserPassword(ctx context.Context, arg UpdateUserPasswordParams) error
+	UpdateUserStripeSubscriberID(ctx context.Context, arg UpdateUserStripeSubscriberIDParams) error
 }
 
 var _ Querier = (*Queries)(nil)

--- a/go/internal/query/queries/users.sql
+++ b/go/internal/query/queries/users.sql
@@ -37,3 +37,14 @@ LIMIT 1;
 INSERT INTO users (username, email, encrypted_password, locale, role, time_zone, created_at, updated_at)
 VALUES ($1, $2, $3, $4, 0, 'Asia/Tokyo', NOW(), NOW())
 RETURNING id, username, email, role, locale, created_at, updated_at;
+
+-- name: UpdateUserStripeSubscriberID :exec
+UPDATE users
+SET stripe_subscriber_id = $2, updated_at = NOW()
+WHERE id = $1;
+
+-- name: GetUserByStripeSubscriberID :one
+SELECT id, username, email, role, stripe_subscriber_id, created_at, updated_at
+FROM users
+WHERE stripe_subscriber_id = $1
+LIMIT 1;

--- a/go/internal/query/users.sql.go
+++ b/go/internal/query/users.sql.go
@@ -169,6 +169,38 @@ func (q *Queries) GetUserByID(ctx context.Context, id int64) (GetUserByIDRow, er
 	return i, err
 }
 
+const getUserByStripeSubscriberID = `-- name: GetUserByStripeSubscriberID :one
+SELECT id, username, email, role, stripe_subscriber_id, created_at, updated_at
+FROM users
+WHERE stripe_subscriber_id = $1
+LIMIT 1
+`
+
+type GetUserByStripeSubscriberIDRow struct {
+	ID                 int64         `db:"id"`
+	Username           string        `db:"username"`
+	Email              string        `db:"email"`
+	Role               int32         `db:"role"`
+	StripeSubscriberID sql.NullInt64 `db:"stripe_subscriber_id"`
+	CreatedAt          sql.NullTime  `db:"created_at"`
+	UpdatedAt          sql.NullTime  `db:"updated_at"`
+}
+
+func (q *Queries) GetUserByStripeSubscriberID(ctx context.Context, stripeSubscriberID sql.NullInt64) (GetUserByStripeSubscriberIDRow, error) {
+	row := q.db.QueryRowContext(ctx, getUserByStripeSubscriberID, stripeSubscriberID)
+	var i GetUserByStripeSubscriberIDRow
+	err := row.Scan(
+		&i.ID,
+		&i.Username,
+		&i.Email,
+		&i.Role,
+		&i.StripeSubscriberID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getUserByUsername = `-- name: GetUserByUsername :one
 SELECT id, username, email, role, created_at, updated_at
 FROM users
@@ -212,5 +244,21 @@ type UpdateUserPasswordParams struct {
 
 func (q *Queries) UpdateUserPassword(ctx context.Context, arg UpdateUserPasswordParams) error {
 	_, err := q.db.ExecContext(ctx, updateUserPassword, arg.ID, arg.EncryptedPassword)
+	return err
+}
+
+const updateUserStripeSubscriberID = `-- name: UpdateUserStripeSubscriberID :exec
+UPDATE users
+SET stripe_subscriber_id = $2, updated_at = NOW()
+WHERE id = $1
+`
+
+type UpdateUserStripeSubscriberIDParams struct {
+	ID                 int64         `db:"id"`
+	StripeSubscriberID sql.NullInt64 `db:"stripe_subscriber_id"`
+}
+
+func (q *Queries) UpdateUserStripeSubscriberID(ctx context.Context, arg UpdateUserStripeSubscriberIDParams) error {
+	_, err := q.db.ExecContext(ctx, updateUserStripeSubscriberID, arg.ID, arg.StripeSubscriberID)
 	return err
 }

--- a/go/internal/repository/user.go
+++ b/go/internal/repository/user.go
@@ -3,6 +3,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/annict/annict/go/internal/query"
 )
@@ -35,4 +36,21 @@ func (r *UserRepository) GetByEmail(ctx context.Context, email string) (query.Ge
 // GetByID はユーザーIDでユーザーを検索します
 func (r *UserRepository) GetByID(ctx context.Context, id int64) (query.GetUserByIDRow, error) {
 	return r.queries.GetUserByID(ctx, id)
+}
+
+// UpdateStripeSubscriberID はユーザーのStripeサブスクライバーIDを更新します
+func (r *UserRepository) UpdateStripeSubscriberID(ctx context.Context, userID int64, stripeSubscriberID *int64) error {
+	var nullableID sql.NullInt64
+	if stripeSubscriberID != nil {
+		nullableID = sql.NullInt64{Int64: *stripeSubscriberID, Valid: true}
+	}
+	return r.queries.UpdateUserStripeSubscriberID(ctx, query.UpdateUserStripeSubscriberIDParams{
+		ID:                 userID,
+		StripeSubscriberID: nullableID,
+	})
+}
+
+// GetByStripeSubscriberID はStripeサブスクライバーIDでユーザーを検索します
+func (r *UserRepository) GetByStripeSubscriberID(ctx context.Context, stripeSubscriberID int64) (query.GetUserByStripeSubscriberIDRow, error) {
+	return r.queries.GetUserByStripeSubscriberID(ctx, sql.NullInt64{Int64: stripeSubscriberID, Valid: true})
 }

--- a/go/internal/repository/user_test.go
+++ b/go/internal/repository/user_test.go
@@ -1,0 +1,134 @@
+package repository_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/annict/annict/go/internal/query"
+	"github.com/annict/annict/go/internal/repository"
+	"github.com/annict/annict/go/internal/testutil"
+)
+
+// TestUserRepository_UpdateStripeSubscriberID_Set はStripeサブスクライバーIDを設定できることをテスト
+func TestUserRepository_UpdateStripeSubscriberID_Set(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewUserRepository(queries)
+
+	// ユーザーを作成
+	userID := testutil.NewUserBuilder(t, tx).Build()
+
+	// Stripeサブスクライバーを作成
+	subscriberID := testutil.NewStripeSubscriberBuilder(t, tx).
+		WithStripeStatus("active").
+		Build()
+
+	// StripeサブスクライバーIDを設定
+	err := repo.UpdateStripeSubscriberID(context.Background(), userID, &subscriberID)
+	if err != nil {
+		t.Fatalf("StripeサブスクライバーIDの設定に失敗: %v", err)
+	}
+
+	// 設定されたことを確認
+	user, err := repo.GetByStripeSubscriberID(context.Background(), subscriberID)
+	if err != nil {
+		t.Fatalf("ユーザーの取得に失敗: %v", err)
+	}
+
+	if user.ID != userID {
+		t.Errorf("ユーザーIDが一致しません: got %d, want %d", user.ID, userID)
+	}
+	if !user.StripeSubscriberID.Valid || user.StripeSubscriberID.Int64 != subscriberID {
+		t.Errorf("StripeSubscriberIDが一致しません: got %v, want %d", user.StripeSubscriberID, subscriberID)
+	}
+}
+
+// TestUserRepository_UpdateStripeSubscriberID_Clear はStripeサブスクライバーIDをクリアできることをテスト
+func TestUserRepository_UpdateStripeSubscriberID_Clear(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewUserRepository(queries)
+
+	// ユーザーを作成
+	userID := testutil.NewUserBuilder(t, tx).Build()
+
+	// Stripeサブスクライバーを作成して関連付け
+	subscriberID := testutil.NewStripeSubscriberBuilder(t, tx).
+		WithStripeStatus("active").
+		Build()
+
+	err := repo.UpdateStripeSubscriberID(context.Background(), userID, &subscriberID)
+	if err != nil {
+		t.Fatalf("StripeサブスクライバーIDの設定に失敗: %v", err)
+	}
+
+	// StripeサブスクライバーIDをクリア
+	err = repo.UpdateStripeSubscriberID(context.Background(), userID, nil)
+	if err != nil {
+		t.Fatalf("StripeサブスクライバーIDのクリアに失敗: %v", err)
+	}
+
+	// クリアされたことを確認（GetByStripeSubscriberIDでは見つからないはず）
+	_, err = repo.GetByStripeSubscriberID(context.Background(), subscriberID)
+	if err == nil {
+		t.Error("クリア後のユーザーが見つかるべきではありません")
+	}
+	if err != sql.ErrNoRows {
+		t.Errorf("期待するエラーではありません: got %v, want %v", err, sql.ErrNoRows)
+	}
+}
+
+// TestUserRepository_GetByStripeSubscriberID は正常にユーザーを取得できることをテスト
+func TestUserRepository_GetByStripeSubscriberID(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewUserRepository(queries)
+
+	// ユーザーを作成
+	userID := testutil.NewUserBuilder(t, tx).
+		WithUsername("stripe_user").
+		WithEmail("stripe@example.com").
+		Build()
+
+	// Stripeサブスクライバーを作成して関連付け
+	subscriberID := testutil.NewStripeSubscriberBuilder(t, tx).
+		WithStripeStatus("active").
+		Build()
+
+	err := repo.UpdateStripeSubscriberID(context.Background(), userID, &subscriberID)
+	if err != nil {
+		t.Fatalf("StripeサブスクライバーIDの設定に失敗: %v", err)
+	}
+
+	// StripeサブスクライバーIDでユーザーを取得
+	user, err := repo.GetByStripeSubscriberID(context.Background(), subscriberID)
+	if err != nil {
+		t.Fatalf("ユーザーの取得に失敗: %v", err)
+	}
+
+	if user.ID != userID {
+		t.Errorf("ユーザーIDが一致しません: got %d, want %d", user.ID, userID)
+	}
+	if user.Username != "stripe_user" {
+		t.Errorf("ユーザー名が一致しません: got %s, want %s", user.Username, "stripe_user")
+	}
+	if user.Email != "stripe@example.com" {
+		t.Errorf("メールアドレスが一致しません: got %s, want %s", user.Email, "stripe@example.com")
+	}
+}
+
+// TestUserRepository_GetByStripeSubscriberID_NotFound は存在しないIDの場合エラーが返ることをテスト
+func TestUserRepository_GetByStripeSubscriberID_NotFound(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewUserRepository(queries)
+
+	_, err := repo.GetByStripeSubscriberID(context.Background(), 99999)
+	if err == nil {
+		t.Error("存在しないIDでエラーが返されるべきです")
+	}
+	if err != sql.ErrNoRows {
+		t.Errorf("期待するエラーではありません: got %v, want %v", err, sql.ErrNoRows)
+	}
+}


### PR DESCRIPTION
- dbmateマイグレーション（カラム追加、インデックス、外部キー制約）
- sqlcクエリにUpdateUserStripeSubscriberIDとGetUserByStripeSubscriberIDを追加
- UserRepositoryにUpdateStripeSubscriberIDとGetByStripeSubscriberIDメソッドを追加
- テストを追加