### PR TITLE
Dockerfile.devにStripe CLIを追加

### DIFF
--- a/go/Dockerfile.dev
+++ b/go/Dockerfile.dev
@@ -49,6 +49,14 @@ RUN curl -fsSL -o /usr/local/bin/dbmate https://github.com/amacneil/dbmate/relea
 # https://golangci-lint.run/docs/welcome/install/#install-from-sources
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.6.2
 
+# Stripe CLI のインストール（Webhook のローカルテスト用）
+# https://docs.stripe.com/stripe-cli
+RUN curl -s https://packages.stripe.dev/api/security/keypair/stripe-cli-gpg/public | gpg --dearmor -o /usr/share/keyrings/stripe.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/stripe.gpg] https://packages.stripe.dev/stripe-cli-debian-local stable main" | tee /etc/apt/sources.list.d/stripe.list \
+    && apt update \
+    && apt install -y stripe \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN \
     groupadd -g ${GROUP_ID} ${USERNAME} && \
     useradd -u ${USER_ID} -g ${GROUP_ID} -m -s /bin/bash ${USERNAME} && \


### PR DESCRIPTION
Webhookのローカルテスト用にStripe CLIをインストール。
`stripe listen --forward-to localhost:8080/webhooks/stripe` で ローカル開発環境でWebhookをテストできるようになる。