### PR TITLE
Stripe Webhook受信エンドポイントを実装

### DIFF
--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/annict/annict/go/internal/handler/sign_up_code"
 	"github.com/annict/annict/go/internal/handler/sign_up_username"
 	"github.com/annict/annict/go/internal/handler/supporters"
+	stripewebhook "github.com/annict/annict/go/internal/handler/webhooks/stripe"
 	"github.com/annict/annict/go/internal/i18n"
 	"github.com/annict/annict/go/internal/image"
 	authMiddleware "github.com/annict/annict/go/internal/middleware"
@@ -326,6 +327,10 @@ func main() {
 	gumroadSubscriberRepo := repository.NewGumroadSubscriberRepository(queries)
 	supportersHandler := supporters.NewHandler(cfg, sessionManager, stripeSubscriberRepo, gumroadSubscriberRepo)
 
+	// Stripe Webhookハンドラーの初期化
+	stripeWebhookEventRepo := repository.NewStripeWebhookEventRepository(queries)
+	stripeWebhookHandler := stripewebhook.NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo)
+
 	// 静的ファイルの配信 (Tailwind CLI + esbuild のビルド結果)
 	fileServer := http.FileServer(http.Dir("./static"))
 	r.Handle("/static/*", http.StripPrefix("/static", fileServer))
@@ -360,6 +365,9 @@ func main() {
 
 	// サポーターページ
 	r.Get("/supporters", supportersHandler.Show)
+
+	// Stripe Webhook
+	r.Post("/webhooks/stripe", stripeWebhookHandler.Create)
 
 	// サーバー起動
 	// Dockerコンテナ内で動かす場合、0.0.0.0でリッスンする必要がある

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -69,6 +69,13 @@ type Config struct {
 	SentryEnvironment      string
 	SentryTracesSampleRate float64
 	SentryDebug            bool
+
+	// Stripe（決済）
+	StripeSecretKey      string
+	StripePublishableKey string
+	StripeWebhookSecret  string
+	StripePriceMonthlyID string
+	StripePriceYearlyID  string
 }
 
 // Load は環境変数から設定を読み込みます
@@ -184,6 +191,13 @@ func Load() (*Config, error) {
 	}
 	cfg.SentryTracesSampleRate = parseSentryTracesSampleRate(os.Getenv("ANNICT_SENTRY_TRACES_SAMPLE_RATE"))
 	cfg.SentryDebug = os.Getenv("ANNICT_SENTRY_DEBUG") == "true"
+
+	// Stripe（オプショナル - サポーター決済）
+	cfg.StripeSecretKey = os.Getenv("ANNICT_STRIPE_SECRET_KEY")
+	cfg.StripePublishableKey = os.Getenv("ANNICT_STRIPE_PUBLISHABLE_KEY")
+	cfg.StripeWebhookSecret = os.Getenv("ANNICT_STRIPE_WEBHOOK_SECRET")
+	cfg.StripePriceMonthlyID = os.Getenv("ANNICT_STRIPE_PRICE_MONTHLY")
+	cfg.StripePriceYearlyID = os.Getenv("ANNICT_STRIPE_PRICE_YEARLY")
 
 	// アセットバージョン（Gitコミットハッシュ）を設定
 	cfg.AssetVersion = getGitCommitHash()

--- a/go/internal/handler/webhooks/stripe/create.go
+++ b/go/internal/handler/webhooks/stripe/create.go
@@ -1,0 +1,232 @@
+package stripe
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v84/webhook"
+
+	"github.com/annict/annict/go/internal/model"
+	"github.com/annict/annict/go/internal/repository"
+	annictSentry "github.com/annict/annict/go/internal/sentry"
+)
+
+// 処理対象のイベントタイプ
+const (
+	EventCheckoutSessionCompleted    = "checkout.session.completed"
+	EventCustomerSubscriptionUpdated = "customer.subscription.updated"
+	EventCustomerSubscriptionDeleted = "customer.subscription.deleted"
+	EventInvoicePaymentSucceeded     = "invoice.payment_succeeded"
+	EventInvoicePaymentFailed        = "invoice.payment_failed"
+)
+
+// Create はStripe Webhookを受信して処理します (POST /webhooks/stripe)
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// リクエストボディを読み取り（Stripe署名検証に必要）
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		slog.ErrorContext(ctx, "Webhookリクエストボディの読み取りに失敗", "error", err)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	// Stripe署名を取得
+	sigHeader := r.Header.Get("Stripe-Signature")
+	if sigHeader == "" {
+		slog.WarnContext(ctx, "Stripe-Signatureヘッダーがありません")
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	// Stripe署名検証
+	event, err := webhook.ConstructEvent(body, sigHeader, h.cfg.StripeWebhookSecret)
+	if err != nil {
+		slog.WarnContext(ctx, "Webhook署名検証に失敗", "error", err)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	slog.InfoContext(ctx, "Stripe Webhookを受信",
+		"event_id", event.ID,
+		"event_type", event.Type,
+	)
+
+	// 冪等性チェック: 既に処理済みのイベントかどうか確認
+	exists, err := h.stripeWebhookEventRepo.Exists(ctx, event.ID)
+	if err != nil {
+		slog.ErrorContext(ctx, "Webhookイベント存在チェックに失敗",
+			"error", err,
+			"stripe_event_id", event.ID,
+		)
+		annictSentry.CaptureError(ctx, fmt.Errorf("webhookイベント存在チェックに失敗: %w", err))
+		// 内部エラーでも200を返す（Stripeのリトライを防ぐため）
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if exists {
+		slog.InfoContext(ctx, "既に処理済みのイベントのためスキップ",
+			"stripe_event_id", event.ID,
+		)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// イベントをDBに保存（status=pending）
+	payloadJSON, err := json.Marshal(event)
+	if err != nil {
+		slog.ErrorContext(ctx, "イベントペイロードのJSON変換に失敗",
+			"error", err,
+			"stripe_event_id", event.ID,
+		)
+		annictSentry.CaptureError(ctx, fmt.Errorf("イベントペイロードのJSON変換に失敗: %w", err))
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	webhookEvent, err := h.stripeWebhookEventRepo.Create(ctx, repository.CreateStripeWebhookEventParams{
+		StripeEventID:   event.ID,
+		StripeEventType: string(event.Type),
+		StripePayload:   payloadJSON,
+		Status:          model.WebhookEventStatusPending.String(),
+		ReceivedAt:      time.Now(),
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "Webhookイベントの保存に失敗",
+			"error", err,
+			"stripe_event_id", event.ID,
+		)
+		annictSentry.CaptureError(ctx, fmt.Errorf("webhookイベントの保存に失敗: %w", err))
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// イベントタイプに応じた処理を実行
+	if err := h.processEvent(ctx, &event, webhookEvent.ID); err != nil {
+		slog.ErrorContext(ctx, "Webhookイベント処理に失敗",
+			"error", err,
+			"stripe_event_id", event.ID,
+			"event_type", event.Type,
+		)
+		annictSentry.CaptureError(ctx, fmt.Errorf("webhookイベント処理に失敗 (event_type=%s, stripe_event_id=%s): %w",
+			event.Type, event.ID, err))
+
+		// 処理失敗としてマーク
+		if markErr := h.stripeWebhookEventRepo.MarkAsFailed(ctx, webhookEvent.ID, err.Error()); markErr != nil {
+			slog.ErrorContext(ctx, "Webhookイベントの失敗マークに失敗",
+				"error", markErr,
+				"stripe_event_id", event.ID,
+			)
+		}
+	}
+
+	// Stripeには常に200を返す（リトライを防ぐため）
+	w.WriteHeader(http.StatusOK)
+}
+
+// processEvent はイベントタイプに応じた処理を実行します
+func (h *Handler) processEvent(ctx context.Context, event *stripe.Event, webhookEventID int64) error {
+	switch event.Type {
+	case EventCheckoutSessionCompleted:
+		return h.handleCheckoutSessionCompleted(ctx, event, webhookEventID)
+
+	case EventCustomerSubscriptionUpdated:
+		return h.handleCustomerSubscriptionUpdated(ctx, event, webhookEventID)
+
+	case EventCustomerSubscriptionDeleted:
+		return h.handleCustomerSubscriptionDeleted(ctx, event, webhookEventID)
+
+	case EventInvoicePaymentSucceeded:
+		// ログ記録のみ（追加処理不要）
+		slog.InfoContext(ctx, "支払い成功イベントを受信",
+			"stripe_event_id", event.ID,
+		)
+		if err := h.stripeWebhookEventRepo.MarkAsProcessed(ctx, webhookEventID); err != nil {
+			return fmt.Errorf("イベント処理完了のマークに失敗: %w", err)
+		}
+		return nil
+
+	case EventInvoicePaymentFailed:
+		// ログ記録のみ（Stripe側で自動リトライされるため、特別な処理は不要）
+		slog.WarnContext(ctx, "支払い失敗イベントを受信",
+			"stripe_event_id", event.ID,
+		)
+		if err := h.stripeWebhookEventRepo.MarkAsProcessed(ctx, webhookEventID); err != nil {
+			return fmt.Errorf("イベント処理完了のマークに失敗: %w", err)
+		}
+		return nil
+
+	default:
+		// 処理対象外のイベント
+		slog.InfoContext(ctx, "処理対象外のイベントをスキップ",
+			"stripe_event_id", event.ID,
+			"event_type", event.Type,
+		)
+		if err := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); err != nil {
+			return fmt.Errorf("イベントスキップのマークに失敗: %w", err)
+		}
+		return nil
+	}
+}
+
+// handleCheckoutSessionCompleted はcheckout.session.completedイベントを処理します
+// タスク3-2で実装予定
+func (h *Handler) handleCheckoutSessionCompleted(ctx context.Context, event *stripe.Event, webhookEventID int64) error {
+	slog.InfoContext(ctx, "checkout.session.completedイベントを受信（未実装）",
+		"stripe_event_id", event.ID,
+	)
+
+	// TODO: タスク3-2で実装
+	// - Checkoutセッションからサブスクリプション情報を取得
+	// - StripeSubscriberレコードを作成
+	// - Userとの紐付け
+
+	if err := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); err != nil {
+		return fmt.Errorf("イベントスキップのマークに失敗: %w", err)
+	}
+
+	return nil
+}
+
+// handleCustomerSubscriptionUpdated はcustomer.subscription.updatedイベントを処理します
+// タスク3-3で実装予定
+func (h *Handler) handleCustomerSubscriptionUpdated(ctx context.Context, event *stripe.Event, webhookEventID int64) error {
+	slog.InfoContext(ctx, "customer.subscription.updatedイベントを受信（未実装）",
+		"stripe_event_id", event.ID,
+	)
+
+	// TODO: タスク3-3で実装
+	// - サブスクリプション状態の更新
+
+	if err := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); err != nil {
+		return fmt.Errorf("イベントスキップのマークに失敗: %w", err)
+	}
+
+	return nil
+}
+
+// handleCustomerSubscriptionDeleted はcustomer.subscription.deletedイベントを処理します
+// タスク3-3で実装予定
+func (h *Handler) handleCustomerSubscriptionDeleted(ctx context.Context, event *stripe.Event, webhookEventID int64) error {
+	slog.InfoContext(ctx, "customer.subscription.deletedイベントを受信（未実装）",
+		"stripe_event_id", event.ID,
+	)
+
+	// TODO: タスク3-3で実装
+	// - サブスクリプションの終了処理
+	// - Userとの紐付け解除
+
+	if err := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); err != nil {
+		return fmt.Errorf("イベントスキップのマークに失敗: %w", err)
+	}
+
+	return nil
+}

--- a/go/internal/handler/webhooks/stripe/create_test.go
+++ b/go/internal/handler/webhooks/stripe/create_test.go
@@ -1,0 +1,282 @@
+package stripe
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/annict/annict/go/internal/config"
+	"github.com/annict/annict/go/internal/query"
+	"github.com/annict/annict/go/internal/repository"
+	"github.com/annict/annict/go/internal/testutil"
+)
+
+// generateStripeSignature はテスト用のStripe Webhook署名を生成します
+func generateStripeSignature(payload []byte, secret string, timestamp int64) string {
+	signedPayload := fmt.Sprintf("%d.%s", timestamp, string(payload))
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(signedPayload))
+	signature := hex.EncodeToString(h.Sum(nil))
+	return fmt.Sprintf("t=%d,v1=%s", timestamp, signature)
+}
+
+func TestCreate_SignatureValidation(t *testing.T) {
+	t.Parallel()
+
+	// テストDBをセットアップ
+	_, tx := testutil.SetupTestDB(t)
+	queries := query.New(tx)
+
+	// テスト用の設定
+	webhookSecret := "whsec_test_secret_12345"
+	cfg := &config.Config{
+		StripeWebhookSecret: webhookSecret,
+	}
+
+	// リポジトリの作成
+	stripeWebhookEventRepo := repository.NewStripeWebhookEventRepository(queries)
+	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
+	userRepo := repository.NewUserRepository(queries)
+
+	// ハンドラーの作成
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo)
+
+	tests := []struct {
+		name           string
+		payload        string
+		signature      string
+		wantStatusCode int
+	}{
+		{
+			name: "署名がないリクエストは400を返す",
+			payload: `{
+				"id": "evt_test_123",
+				"type": "checkout.session.completed",
+				"data": {}
+			}`,
+			signature:      "",
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name: "不正な署名は400を返す",
+			payload: `{
+				"id": "evt_test_123",
+				"type": "checkout.session.completed",
+				"data": {}
+			}`,
+			signature:      "t=12345,v1=invalid_signature",
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name: "正しい署名は200を返す",
+			payload: `{
+				"id": "evt_test_valid_signature",
+				"object": "event",
+				"type": "checkout.session.completed",
+				"data": {"object": {}},
+				"livemode": false,
+				"api_version": "2025-12-15.clover",
+				"created": 1234567890,
+				"pending_webhooks": 0,
+				"request": {"id": null, "idempotency_key": null}
+			}`,
+			signature:      "valid", // 後で正しい署名に置き換え
+			wantStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			signature := tt.signature
+
+			// 正しい署名が必要な場合は生成
+			if tt.signature == "valid" {
+				timestamp := time.Now().Unix()
+				signature = generateStripeSignature([]byte(tt.payload), webhookSecret, timestamp)
+			}
+
+			// リクエストを作成
+			req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", strings.NewReader(tt.payload))
+			req.Header.Set("Content-Type", "application/json")
+			if signature != "" {
+				req.Header.Set("Stripe-Signature", signature)
+			}
+
+			// レスポンスを記録
+			rr := httptest.NewRecorder()
+
+			// ハンドラーを実行
+			handler.Create(rr, req)
+
+			// ステータスコードを確認
+			if rr.Code != tt.wantStatusCode {
+				t.Errorf("ステータスコード: got %d, want %d", rr.Code, tt.wantStatusCode)
+			}
+		})
+	}
+}
+
+func TestCreate_Idempotency(t *testing.T) {
+	t.Parallel()
+
+	// テストDBをセットアップ
+	_, tx := testutil.SetupTestDB(t)
+	queries := query.New(tx)
+
+	// テスト用の設定
+	webhookSecret := "whsec_test_secret_12345"
+	cfg := &config.Config{
+		StripeWebhookSecret: webhookSecret,
+	}
+
+	// リポジトリの作成
+	stripeWebhookEventRepo := repository.NewStripeWebhookEventRepository(queries)
+	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
+	userRepo := repository.NewUserRepository(queries)
+
+	// ハンドラーの作成
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo)
+
+	// 既にイベントを登録
+	existingEventID := "evt_existing_event_123"
+	testutil.NewStripeWebhookEventBuilder(t, tx).
+		WithStripeEventID(existingEventID).
+		WithStripeEventType("checkout.session.completed").
+		WithStatus("processed").
+		Build()
+
+	// 同じイベントIDで再度リクエストを送信
+	payload := fmt.Sprintf(`{
+		"id": "%s",
+		"object": "event",
+		"type": "checkout.session.completed",
+		"data": {"object": {}},
+		"livemode": false,
+		"api_version": "2025-12-15.clover",
+		"created": 1234567890,
+		"pending_webhooks": 0,
+		"request": {"id": null, "idempotency_key": null}
+	}`, existingEventID)
+
+	timestamp := time.Now().Unix()
+	signature := generateStripeSignature([]byte(payload), webhookSecret, timestamp)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Stripe-Signature", signature)
+
+	rr := httptest.NewRecorder()
+	handler.Create(rr, req)
+
+	// 200を返す（冪等性による重複スキップ）
+	if rr.Code != http.StatusOK {
+		t.Errorf("冪等性チェック後のステータスコード: got %d, want %d", rr.Code, http.StatusOK)
+	}
+}
+
+func TestCreate_EventProcessing(t *testing.T) {
+	t.Parallel()
+
+	// テストDBをセットアップ
+	_, tx := testutil.SetupTestDB(t)
+	queries := query.New(tx)
+
+	// テスト用の設定
+	webhookSecret := "whsec_test_secret_12345"
+	cfg := &config.Config{
+		StripeWebhookSecret: webhookSecret,
+	}
+
+	// リポジトリの作成
+	stripeWebhookEventRepo := repository.NewStripeWebhookEventRepository(queries)
+	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
+	userRepo := repository.NewUserRepository(queries)
+
+	// ハンドラーの作成
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo)
+
+	tests := []struct {
+		name           string
+		eventType      string
+		wantStatusCode int
+	}{
+		{
+			name:           "checkout.session.completedイベントを処理",
+			eventType:      "checkout.session.completed",
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:           "customer.subscription.updatedイベントを処理",
+			eventType:      "customer.subscription.updated",
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:           "customer.subscription.deletedイベントを処理",
+			eventType:      "customer.subscription.deleted",
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:           "invoice.payment_succeededイベントを処理",
+			eventType:      "invoice.payment_succeeded",
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:           "invoice.payment_failedイベントを処理",
+			eventType:      "invoice.payment_failed",
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name:           "処理対象外のイベントはスキップ",
+			eventType:      "product.created",
+			wantStatusCode: http.StatusOK,
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// 一意のイベントIDを生成
+			eventID := fmt.Sprintf("evt_test_%s_%d", tt.eventType, i)
+
+			payload := fmt.Sprintf(`{
+				"id": "%s",
+				"object": "event",
+				"type": "%s",
+				"data": {"object": {}},
+				"livemode": false,
+				"api_version": "2025-12-15.clover",
+				"created": 1234567890,
+				"pending_webhooks": 0,
+				"request": {"id": null, "idempotency_key": null}
+			}`, eventID, tt.eventType)
+
+			timestamp := time.Now().Unix()
+			signature := generateStripeSignature([]byte(payload), webhookSecret, timestamp)
+
+			req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", strings.NewReader(payload))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Stripe-Signature", signature)
+
+			rr := httptest.NewRecorder()
+			handler.Create(rr, req)
+
+			if rr.Code != tt.wantStatusCode {
+				t.Errorf("ステータスコード: got %d, want %d", rr.Code, tt.wantStatusCode)
+			}
+
+			// イベントがDBに保存されていることを確認
+			savedEvent, err := stripeWebhookEventRepo.GetByStripeEventID(req.Context(), eventID)
+			if err != nil {
+				t.Errorf("イベントがDBに保存されていません: %v", err)
+			}
+			if savedEvent.StripeEventType != tt.eventType {
+				t.Errorf("イベントタイプ: got %s, want %s", savedEvent.StripeEventType, tt.eventType)
+			}
+		})
+	}
+}

--- a/go/internal/handler/webhooks/stripe/handler.go
+++ b/go/internal/handler/webhooks/stripe/handler.go
@@ -1,0 +1,30 @@
+// Package stripe はStripe Webhook関連のハンドラーを提供します
+package stripe
+
+import (
+	"github.com/annict/annict/go/internal/config"
+	"github.com/annict/annict/go/internal/repository"
+)
+
+// Handler はStripe Webhook関連のHTTPハンドラーです
+type Handler struct {
+	cfg                    *config.Config
+	stripeWebhookEventRepo *repository.StripeWebhookEventRepository
+	stripeSubscriberRepo   *repository.StripeSubscriberRepository
+	userRepo               *repository.UserRepository
+}
+
+// NewHandler は新しいHandlerを作成します
+func NewHandler(
+	cfg *config.Config,
+	stripeWebhookEventRepo *repository.StripeWebhookEventRepository,
+	stripeSubscriberRepo *repository.StripeSubscriberRepository,
+	userRepo *repository.UserRepository,
+) *Handler {
+	return &Handler{
+		cfg:                    cfg,
+		stripeWebhookEventRepo: stripeWebhookEventRepo,
+		stripeSubscriberRepo:   stripeSubscriberRepo,
+		userRepo:               userRepo,
+	}
+}

--- a/go/internal/middleware/reverse_proxy.go
+++ b/go/internal/middleware/reverse_proxy.go
@@ -34,6 +34,7 @@ var goHandledPaths = []string{
 	"/password/edit",    // パスワードリセット実行
 	"/password",         // パスワード更新
 	"/supporters",       // サポーターページ
+	"/webhooks/stripe",  // Stripe Webhook受信
 }
 
 // NewReverseProxyMiddleware は新しいReverseProxyMiddlewareを作成

--- a/go/internal/repository/stripe_webhook_event.go
+++ b/go/internal/repository/stripe_webhook_event.go
@@ -3,11 +3,24 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"time"
 
 	"github.com/annict/annict/go/internal/model"
 	"github.com/annict/annict/go/internal/query"
 )
+
+// StripeWebhookEvent はWebhookイベントの型エイリアスです
+type StripeWebhookEvent = query.StripeWebhookEvent
+
+// CreateStripeWebhookEventParams はWebhookイベント作成時のパラメータです
+type CreateStripeWebhookEventParams struct {
+	StripeEventID   string
+	StripeEventType string
+	StripePayload   json.RawMessage
+	Status          string
+	ReceivedAt      time.Time
+}
 
 // StripeWebhookEventRepository はStripe Webhookイベントのリポジトリです
 type StripeWebhookEventRepository struct {
@@ -20,8 +33,14 @@ func NewStripeWebhookEventRepository(queries *query.Queries) *StripeWebhookEvent
 }
 
 // Create は新しいWebhookイベントを作成します
-func (r *StripeWebhookEventRepository) Create(ctx context.Context, params query.CreateStripeWebhookEventParams) (query.StripeWebhookEvent, error) {
-	return r.queries.CreateStripeWebhookEvent(ctx, params)
+func (r *StripeWebhookEventRepository) Create(ctx context.Context, params CreateStripeWebhookEventParams) (StripeWebhookEvent, error) {
+	return r.queries.CreateStripeWebhookEvent(ctx, query.CreateStripeWebhookEventParams{
+		StripeEventID:   params.StripeEventID,
+		StripeEventType: params.StripeEventType,
+		StripePayload:   params.StripePayload,
+		Status:          params.Status,
+		ReceivedAt:      params.ReceivedAt,
+	})
 }
 
 // GetByStripeEventID はStripe Event IDでWebhookイベントを取得します

--- a/go/internal/repository/stripe_webhook_event_test.go
+++ b/go/internal/repository/stripe_webhook_event_test.go
@@ -20,7 +20,7 @@ func TestStripeWebhookEventRepository_Create(t *testing.T) {
 	repo := repository.NewStripeWebhookEventRepository(queries)
 
 	now := time.Now()
-	params := query.CreateStripeWebhookEventParams{
+	params := repository.CreateStripeWebhookEventParams{
 		StripeEventID:   "evt_test_create",
 		StripeEventType: "customer.subscription.created",
 		StripePayload:   json.RawMessage(`{"id": "evt_test_create", "type": "customer.subscription.created"}`),


### PR DESCRIPTION
- internal/handler/webhooks/stripe/ ディレクトリを作成
- Stripe署名検証の実装
- 冪等性処理（stripe_event_idでの重複チェック）
- イベントディスパッチャー（5種類のイベントタイプに対応）
- エラー発生時のSentry通知
- リバースプロキシホワイトリストに /webhooks/stripe を追加
- Stripe設定を config.Config に追加