### PR TITLE
checkout.session.completedイベント処理を実装

### DIFF
--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -329,7 +329,8 @@ func main() {
 
 	// Stripe Webhookハンドラーの初期化
 	stripeWebhookEventRepo := repository.NewStripeWebhookEventRepository(queries)
-	stripeWebhookHandler := stripewebhook.NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo)
+	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	stripeWebhookHandler := stripewebhook.NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC)
 
 	// 静的ファイルの配信 (Tailwind CLI + esbuild のビルド結果)
 	fileServer := http.FileServer(http.Dir("./static"))

--- a/go/internal/handler/webhooks/stripe/create.go
+++ b/go/internal/handler/webhooks/stripe/create.go
@@ -15,6 +15,7 @@ import (
 	"github.com/annict/annict/go/internal/model"
 	"github.com/annict/annict/go/internal/repository"
 	annictSentry "github.com/annict/annict/go/internal/sentry"
+	"github.com/annict/annict/go/internal/usecase"
 )
 
 // 処理対象のイベントタイプ
@@ -178,19 +179,55 @@ func (h *Handler) processEvent(ctx context.Context, event *stripe.Event, webhook
 }
 
 // handleCheckoutSessionCompleted はcheckout.session.completedイベントを処理します
-// タスク3-2で実装予定
 func (h *Handler) handleCheckoutSessionCompleted(ctx context.Context, event *stripe.Event, webhookEventID int64) error {
-	slog.InfoContext(ctx, "checkout.session.completedイベントを受信（未実装）",
+	slog.InfoContext(ctx, "checkout.session.completedイベントを受信",
 		"stripe_event_id", event.ID,
 	)
 
-	// TODO: タスク3-2で実装
-	// - Checkoutセッションからサブスクリプション情報を取得
-	// - StripeSubscriberレコードを作成
-	// - Userとの紐付け
+	// イベントデータからチェックアウトセッションを取得
+	var session stripe.CheckoutSession
+	if err := json.Unmarshal(event.Data.Raw, &session); err != nil {
+		return fmt.Errorf("チェックアウトセッションのパースに失敗: %w", err)
+	}
 
-	if err := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); err != nil {
-		return fmt.Errorf("イベントスキップのマークに失敗: %w", err)
+	// サブスクリプションIDがない場合はスキップ（一回限りの支払いなど）
+	if session.Subscription == nil {
+		slog.InfoContext(ctx, "サブスクリプションIDがないためスキップ",
+			"stripe_event_id", event.ID,
+		)
+		if err := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); err != nil {
+			return fmt.Errorf("イベントスキップのマークに失敗: %w", err)
+		}
+		return nil
+	}
+
+	// metadataからユーザーIDを取得
+	userID, err := usecase.ParseUserIDFromMetadata(session.Metadata)
+	if err != nil {
+		return fmt.Errorf("ユーザーID取得に失敗: %w", err)
+	}
+
+	// StripeSubscriberを作成してUserと紐付け
+	input := usecase.CreateStripeSubscriberInput{
+		StripeCustomerID:     session.Customer.ID,
+		StripeSubscriptionID: session.Subscription.ID,
+		UserID:               userID,
+	}
+
+	result, err := h.createStripeSubscriberUC.Execute(ctx, input)
+	if err != nil {
+		return fmt.Errorf("StripeSubscriber作成に失敗: %w", err)
+	}
+
+	slog.InfoContext(ctx, "StripeSubscriberを作成しました",
+		"stripe_event_id", event.ID,
+		"stripe_subscriber_id", result.StripeSubscriber.ID,
+		"user_id", userID,
+	)
+
+	// 処理完了としてマーク
+	if err := h.stripeWebhookEventRepo.MarkAsProcessed(ctx, webhookEventID); err != nil {
+		return fmt.Errorf("イベント処理完了のマークに失敗: %w", err)
 	}
 
 	return nil

--- a/go/internal/handler/webhooks/stripe/create_test.go
+++ b/go/internal/handler/webhooks/stripe/create_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/annict/annict/go/internal/query"
 	"github.com/annict/annict/go/internal/repository"
 	"github.com/annict/annict/go/internal/testutil"
+	"github.com/annict/annict/go/internal/usecase"
 )
 
 // generateStripeSignature はテスト用のStripe Webhook署名を生成します
@@ -30,7 +31,7 @@ func TestCreate_SignatureValidation(t *testing.T) {
 	t.Parallel()
 
 	// テストDBをセットアップ
-	_, tx := testutil.SetupTestDB(t)
+	db, tx := testutil.SetupTestDB(t)
 	queries := query.New(tx)
 
 	// テスト用の設定
@@ -44,8 +45,11 @@ func TestCreate_SignatureValidation(t *testing.T) {
 	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
 	userRepo := repository.NewUserRepository(queries)
 
+	// UseCaseの作成
+	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+
 	// ハンドラーの作成
-	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo)
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC)
 
 	tests := []struct {
 		name           string
@@ -126,7 +130,7 @@ func TestCreate_Idempotency(t *testing.T) {
 	t.Parallel()
 
 	// テストDBをセットアップ
-	_, tx := testutil.SetupTestDB(t)
+	db, tx := testutil.SetupTestDB(t)
 	queries := query.New(tx)
 
 	// テスト用の設定
@@ -140,8 +144,11 @@ func TestCreate_Idempotency(t *testing.T) {
 	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
 	userRepo := repository.NewUserRepository(queries)
 
+	// UseCaseの作成
+	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+
 	// ハンドラーの作成
-	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo)
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC)
 
 	// 既にイベントを登録
 	existingEventID := "evt_existing_event_123"
@@ -184,7 +191,7 @@ func TestCreate_EventProcessing(t *testing.T) {
 	t.Parallel()
 
 	// テストDBをセットアップ
-	_, tx := testutil.SetupTestDB(t)
+	db, tx := testutil.SetupTestDB(t)
 	queries := query.New(tx)
 
 	// テスト用の設定
@@ -198,8 +205,11 @@ func TestCreate_EventProcessing(t *testing.T) {
 	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
 	userRepo := repository.NewUserRepository(queries)
 
+	// UseCaseの作成
+	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+
 	// ハンドラーの作成
-	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo)
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC)
 
 	tests := []struct {
 		name           string

--- a/go/internal/handler/webhooks/stripe/handler.go
+++ b/go/internal/handler/webhooks/stripe/handler.go
@@ -4,14 +4,16 @@ package stripe
 import (
 	"github.com/annict/annict/go/internal/config"
 	"github.com/annict/annict/go/internal/repository"
+	"github.com/annict/annict/go/internal/usecase"
 )
 
 // Handler はStripe Webhook関連のHTTPハンドラーです
 type Handler struct {
-	cfg                    *config.Config
-	stripeWebhookEventRepo *repository.StripeWebhookEventRepository
-	stripeSubscriberRepo   *repository.StripeSubscriberRepository
-	userRepo               *repository.UserRepository
+	cfg                      *config.Config
+	stripeWebhookEventRepo   *repository.StripeWebhookEventRepository
+	stripeSubscriberRepo     *repository.StripeSubscriberRepository
+	userRepo                 *repository.UserRepository
+	createStripeSubscriberUC *usecase.CreateStripeSubscriberUsecase
 }
 
 // NewHandler は新しいHandlerを作成します
@@ -20,11 +22,13 @@ func NewHandler(
 	stripeWebhookEventRepo *repository.StripeWebhookEventRepository,
 	stripeSubscriberRepo *repository.StripeSubscriberRepository,
 	userRepo *repository.UserRepository,
+	createStripeSubscriberUC *usecase.CreateStripeSubscriberUsecase,
 ) *Handler {
 	return &Handler{
-		cfg:                    cfg,
-		stripeWebhookEventRepo: stripeWebhookEventRepo,
-		stripeSubscriberRepo:   stripeSubscriberRepo,
-		userRepo:               userRepo,
+		cfg:                      cfg,
+		stripeWebhookEventRepo:   stripeWebhookEventRepo,
+		stripeSubscriberRepo:     stripeSubscriberRepo,
+		userRepo:                 userRepo,
+		createStripeSubscriberUC: createStripeSubscriberUC,
 	}
 }

--- a/go/internal/usecase/create_stripe_subscriber.go
+++ b/go/internal/usecase/create_stripe_subscriber.go
@@ -1,0 +1,186 @@
+// Package usecase はビジネスロジック層のユースケースを提供します
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/stripe/stripe-go/v84/subscription"
+
+	"github.com/annict/annict/go/internal/model"
+	"github.com/annict/annict/go/internal/query"
+	"github.com/annict/annict/go/internal/repository"
+)
+
+// CreateStripeSubscriberUsecase はcheckout.session.completedイベント処理のユースケース
+type CreateStripeSubscriberUsecase struct {
+	db                   *sql.DB
+	stripeSubscriberRepo *repository.StripeSubscriberRepository
+	userRepo             *repository.UserRepository
+}
+
+// NewCreateStripeSubscriberUsecase はCreateStripeSubscriberUsecaseを作成します
+func NewCreateStripeSubscriberUsecase(
+	db *sql.DB,
+	stripeSubscriberRepo *repository.StripeSubscriberRepository,
+	userRepo *repository.UserRepository,
+) *CreateStripeSubscriberUsecase {
+	return &CreateStripeSubscriberUsecase{
+		db:                   db,
+		stripeSubscriberRepo: stripeSubscriberRepo,
+		userRepo:             userRepo,
+	}
+}
+
+// CreateStripeSubscriberInput はcheckout.session.completedイベントの入力データ
+type CreateStripeSubscriberInput struct {
+	StripeCustomerID     string // Stripeの顧客ID (cus_xxx)
+	StripeSubscriptionID string // StripeのサブスクリプションID (sub_xxx)
+	UserID               int64  // AnnictのユーザーID（metadataから取得）
+}
+
+// CreateStripeSubscriberResult はcheckout.session.completedイベント処理の結果
+type CreateStripeSubscriberResult struct {
+	StripeSubscriber query.StripeSubscriber
+}
+
+// Execute はcheckout.session.completedイベントを処理します
+//
+// 処理フロー:
+// 1. Stripe APIからサブスクリプション詳細を取得
+// 2. StripeSubscriberレコードを作成
+// 3. Userとの紐付け
+func (uc *CreateStripeSubscriberUsecase) Execute(
+	ctx context.Context,
+	input CreateStripeSubscriberInput,
+) (*CreateStripeSubscriberResult, error) {
+	// Stripe APIからサブスクリプション詳細を取得
+	sub, err := subscription.Get(input.StripeSubscriptionID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("サブスクリプション取得に失敗: %w", err)
+	}
+
+	// ステータスを検証
+	status := model.StripeSubscriptionStatus(sub.Status)
+	if !status.IsValid() {
+		return nil, &InvalidSubscriptionStatusError{Status: string(sub.Status)}
+	}
+
+	// 価格IDと請求期間を取得（最初のアイテムから）
+	if len(sub.Items.Data) == 0 {
+		return nil, fmt.Errorf("サブスクリプションにアイテムが含まれていません")
+	}
+	item := sub.Items.Data[0]
+	priceID := item.Price.ID
+
+	// トランザクション開始
+	tx, err := uc.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("トランザクション開始に失敗: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// StripeSubscriberレコードを作成
+	stripeSubscriber, err := uc.stripeSubscriberRepo.Create(ctx, query.CreateStripeSubscriberParams{
+		StripeCustomerID:         input.StripeCustomerID,
+		StripeSubscriptionID:     input.StripeSubscriptionID,
+		StripePriceID:            priceID,
+		StripeStatus:             string(sub.Status),
+		StripeCurrentPeriodStart: time.Unix(item.CurrentPeriodStart, 0),
+		StripeCurrentPeriodEnd:   time.Unix(item.CurrentPeriodEnd, 0),
+		StripeCancelAt:           nullTimeFromUnix(sub.CancelAt),
+		StripeCanceledAt:         nullTimeFromUnix(sub.CanceledAt),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("StripeSubscriber作成に失敗: %w", err)
+	}
+
+	// ユーザーとの紐付け
+	err = uc.userRepo.UpdateStripeSubscriberID(ctx, input.UserID, &stripeSubscriber.ID)
+	if err != nil {
+		return nil, fmt.Errorf("ユーザー紐付けに失敗: %w", err)
+	}
+
+	// トランザクションコミット
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("トランザクションコミットに失敗: %w", err)
+	}
+
+	return &CreateStripeSubscriberResult{
+		StripeSubscriber: stripeSubscriber,
+	}, nil
+}
+
+// nullTimeFromUnix はUnixタイムスタンプからsql.NullTimeを作成します
+// 値が0の場合はValidがfalseになります
+func nullTimeFromUnix(ts int64) sql.NullTime {
+	if ts == 0 {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{
+		Time:  time.Unix(ts, 0),
+		Valid: true,
+	}
+}
+
+// ParseUserIDFromMetadata はCheckoutセッションのmetadataからユーザーIDを取得します
+func ParseUserIDFromMetadata(metadata map[string]string) (int64, error) {
+	userIDStr, ok := metadata["user_id"]
+	if !ok {
+		return 0, &MetadataUserIDMissingError{}
+	}
+
+	userID, err := strconv.ParseInt(userIDStr, 10, 64)
+	if err != nil {
+		return 0, &MetadataUserIDInvalidError{Value: userIDStr}
+	}
+
+	return userID, nil
+}
+
+// InvalidSubscriptionStatusError は無効なサブスクリプションステータスを示すエラー
+type InvalidSubscriptionStatusError struct {
+	Status string
+}
+
+func (e *InvalidSubscriptionStatusError) Error() string {
+	return fmt.Sprintf("invalid subscription status: %s", e.Status)
+}
+
+// IsInvalidSubscriptionStatusError はエラーがInvalidSubscriptionStatusErrorかどうかを判定します
+func IsInvalidSubscriptionStatusError(err error) bool {
+	var e *InvalidSubscriptionStatusError
+	return errors.As(err, &e)
+}
+
+// MetadataUserIDMissingError はmetadataにuser_idが含まれていないことを示すエラー
+type MetadataUserIDMissingError struct{}
+
+func (e *MetadataUserIDMissingError) Error() string {
+	return "user_id is missing from metadata"
+}
+
+// IsMetadataUserIDMissingError はエラーがMetadataUserIDMissingErrorかどうかを判定します
+func IsMetadataUserIDMissingError(err error) bool {
+	var e *MetadataUserIDMissingError
+	return errors.As(err, &e)
+}
+
+// MetadataUserIDInvalidError はmetadataのuser_idが無効であることを示すエラー
+type MetadataUserIDInvalidError struct {
+	Value string
+}
+
+func (e *MetadataUserIDInvalidError) Error() string {
+	return fmt.Sprintf("invalid user_id in metadata: %s", e.Value)
+}
+
+// IsMetadataUserIDInvalidError はエラーがMetadataUserIDInvalidErrorかどうかを判定します
+func IsMetadataUserIDInvalidError(err error) bool {
+	var e *MetadataUserIDInvalidError
+	return errors.As(err, &e)
+}

--- a/go/internal/usecase/create_stripe_subscriber_test.go
+++ b/go/internal/usecase/create_stripe_subscriber_test.go
@@ -1,0 +1,192 @@
+package usecase
+
+import (
+	"testing"
+)
+
+func TestParseUserIDFromMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		metadata  map[string]string
+		wantID    int64
+		wantError bool
+		errorType string
+	}{
+		{
+			name:      "user_idが存在しない場合はエラー",
+			metadata:  map[string]string{},
+			wantID:    0,
+			wantError: true,
+			errorType: "MetadataUserIDMissingError",
+		},
+		{
+			name:      "user_idが空の場合はエラー",
+			metadata:  map[string]string{"user_id": ""},
+			wantID:    0,
+			wantError: true,
+			errorType: "MetadataUserIDInvalidError",
+		},
+		{
+			name:      "user_idが数値でない場合はエラー",
+			metadata:  map[string]string{"user_id": "abc"},
+			wantID:    0,
+			wantError: true,
+			errorType: "MetadataUserIDInvalidError",
+		},
+		{
+			name:      "user_idが正しい場合は成功",
+			metadata:  map[string]string{"user_id": "12345"},
+			wantID:    12345,
+			wantError: false,
+		},
+		{
+			name:      "user_idが0でも成功",
+			metadata:  map[string]string{"user_id": "0"},
+			wantID:    0,
+			wantError: false,
+		},
+		{
+			name:      "user_idが負の値でも成功",
+			metadata:  map[string]string{"user_id": "-1"},
+			wantID:    -1,
+			wantError: false,
+		},
+		{
+			name:      "他のキーが含まれていても成功",
+			metadata:  map[string]string{"user_id": "999", "plan": "monthly"},
+			wantID:    999,
+			wantError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			userID, err := ParseUserIDFromMetadata(tt.metadata)
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、nilが返されました")
+					return
+				}
+
+				switch tt.errorType {
+				case "MetadataUserIDMissingError":
+					if !IsMetadataUserIDMissingError(err) {
+						t.Errorf("MetadataUserIDMissingErrorが期待されましたが、%v が返されました", err)
+					}
+				case "MetadataUserIDInvalidError":
+					if !IsMetadataUserIDInvalidError(err) {
+						t.Errorf("MetadataUserIDInvalidErrorが期待されましたが、%v が返されました", err)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			if userID != tt.wantID {
+				t.Errorf("userID: got %d, want %d", userID, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestNullTimeFromUnix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		timestamp int64
+		wantValid bool
+	}{
+		{
+			name:      "0の場合はValidがfalse",
+			timestamp: 0,
+			wantValid: false,
+		},
+		{
+			name:      "正の値の場合はValidがtrue",
+			timestamp: 1609459200, // 2021-01-01 00:00:00 UTC
+			wantValid: true,
+		},
+		{
+			name:      "負の値の場合もValidがtrue",
+			timestamp: -1,
+			wantValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := nullTimeFromUnix(tt.timestamp)
+
+			if result.Valid != tt.wantValid {
+				t.Errorf("Valid: got %v, want %v", result.Valid, tt.wantValid)
+			}
+
+			if tt.wantValid && result.Time.Unix() != tt.timestamp {
+				t.Errorf("Time.Unix(): got %d, want %d", result.Time.Unix(), tt.timestamp)
+			}
+		})
+	}
+}
+
+func TestInvalidSubscriptionStatusError(t *testing.T) {
+	t.Parallel()
+
+	err := &InvalidSubscriptionStatusError{Status: "unknown"}
+
+	// Error()メソッドのテスト
+	expected := "invalid subscription status: unknown"
+	if err.Error() != expected {
+		t.Errorf("Error(): got %q, want %q", err.Error(), expected)
+	}
+
+	// IsInvalidSubscriptionStatusErrorのテスト
+	if !IsInvalidSubscriptionStatusError(err) {
+		t.Error("IsInvalidSubscriptionStatusError: got false, want true")
+	}
+}
+
+func TestMetadataUserIDMissingError(t *testing.T) {
+	t.Parallel()
+
+	err := &MetadataUserIDMissingError{}
+
+	// Error()メソッドのテスト
+	expected := "user_id is missing from metadata"
+	if err.Error() != expected {
+		t.Errorf("Error(): got %q, want %q", err.Error(), expected)
+	}
+
+	// IsMetadataUserIDMissingErrorのテスト
+	if !IsMetadataUserIDMissingError(err) {
+		t.Error("IsMetadataUserIDMissingError: got false, want true")
+	}
+}
+
+func TestMetadataUserIDInvalidError(t *testing.T) {
+	t.Parallel()
+
+	err := &MetadataUserIDInvalidError{Value: "abc"}
+
+	// Error()メソッドのテスト
+	expected := "invalid user_id in metadata: abc"
+	if err.Error() != expected {
+		t.Errorf("Error(): got %q, want %q", err.Error(), expected)
+	}
+
+	// IsMetadataUserIDInvalidErrorのテスト
+	if !IsMetadataUserIDInvalidError(err) {
+		t.Error("IsMetadataUserIDInvalidError: got false, want true")
+	}
+}


### PR DESCRIPTION
- CreateStripeSubscriberUsecaseを作成
  - Stripe APIからサブスクリプション詳細を取得
  - StripeSubscriberレコードを作成
  - ユーザーとの紐付け処理
- handleCheckoutSessionCompletedを実装
  - チェックアウトセッションのパース
  - metadataからユーザーIDを取得
  - UseCaseを呼び出してStripeSubscriberを作成
- ParseUserIDFromMetadata関数とエラータイプを追加
- 既存テストをUseCase依存に更新