### PR TITLE
customer.subscription.updated/deletedイベント処理を実装

### DIFF
--- a/go/CLAUDE.md
+++ b/go/CLAUDE.md
@@ -780,6 +780,27 @@ Go 版 Annict では、関心の分離を意識したアーキテクチャを採
 - **配置**: `internal/usecase` （フラット構造）
 - **責務**: トランザクション管理、複数リポジトリを跨ぐ処理
 - **命名**: ファイル名 `{action}_{entity}.go`、構造体名 `{Action}{Entity}Usecase`
+- **単一責任**: 各 Usecase は **`Execute` メソッドのみ** を公開する（1 Usecase = 1 操作）
+
+**重要**: 1 つの Usecase に複数の公開メソッド（`Execute`, `ExecuteDelete` など）を持たせないでください。異なる操作が必要な場合は、別の Usecase として分離します。
+
+```go
+// ✅ 良い例: 各Usecaseが単一のExecuteメソッドを持つ
+type CreateStripeSubscriberUsecase struct { ... }
+func (uc *CreateStripeSubscriberUsecase) Execute(ctx, input) (*Result, error)
+
+type UpdateStripeSubscriberUsecase struct { ... }
+func (uc *UpdateStripeSubscriberUsecase) Execute(ctx, input) (*Result, error)
+
+type DeleteStripeSubscriberUsecase struct { ... }
+func (uc *DeleteStripeSubscriberUsecase) Execute(ctx, input) (*Result, error)
+
+// ❌ 悪い例: 1つのUsecaseに複数の公開メソッド
+type StripeSubscriberUsecase struct { ... }
+func (uc *StripeSubscriberUsecase) Create(ctx, input) (*Result, error)
+func (uc *StripeSubscriberUsecase) Update(ctx, input) (*Result, error)
+func (uc *StripeSubscriberUsecase) Delete(ctx, input) (*Result, error)
+```
 
 #### 詳細ドキュメント
 

--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -330,7 +330,8 @@ func main() {
 	// Stripe Webhookハンドラーの初期化
 	stripeWebhookEventRepo := repository.NewStripeWebhookEventRepository(queries)
 	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
-	stripeWebhookHandler := stripewebhook.NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC)
+	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	stripeWebhookHandler := stripewebhook.NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC)
 
 	// 静的ファイルの配信 (Tailwind CLI + esbuild のビルド結果)
 	fileServer := http.FileServer(http.Dir("./static"))

--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -331,7 +331,8 @@ func main() {
 	stripeWebhookEventRepo := repository.NewStripeWebhookEventRepository(queries)
 	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
-	stripeWebhookHandler := stripewebhook.NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC)
+	deleteStripeSubscriberUC := usecase.NewDeleteStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	stripeWebhookHandler := stripewebhook.NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC, deleteStripeSubscriberUC)
 
 	// 静的ファイルの配信 (Tailwind CLI + esbuild のビルド結果)
 	fileServer := http.FileServer(http.Dir("./static"))

--- a/go/internal/handler/webhooks/stripe/create.go
+++ b/go/internal/handler/webhooks/stripe/create.go
@@ -321,7 +321,7 @@ func (h *Handler) handleCustomerSubscriptionDeleted(ctx context.Context, event *
 		StripeCanceledAt:     time.Unix(subscription.CanceledAt, 0),
 	}
 
-	result, err := h.updateStripeSubscriberUC.ExecuteDelete(ctx, input)
+	result, err := h.deleteStripeSubscriberUC.Execute(ctx, input)
 	if err != nil {
 		// サブスクリプションが見つからない場合はスキップ
 		if err == sql.ErrNoRows {

--- a/go/internal/handler/webhooks/stripe/create.go
+++ b/go/internal/handler/webhooks/stripe/create.go
@@ -2,6 +2,7 @@ package stripe
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -234,36 +235,132 @@ func (h *Handler) handleCheckoutSessionCompleted(ctx context.Context, event *str
 }
 
 // handleCustomerSubscriptionUpdated はcustomer.subscription.updatedイベントを処理します
-// タスク3-3で実装予定
 func (h *Handler) handleCustomerSubscriptionUpdated(ctx context.Context, event *stripe.Event, webhookEventID int64) error {
-	slog.InfoContext(ctx, "customer.subscription.updatedイベントを受信（未実装）",
+	slog.InfoContext(ctx, "customer.subscription.updatedイベントを受信",
 		"stripe_event_id", event.ID,
 	)
 
-	// TODO: タスク3-3で実装
-	// - サブスクリプション状態の更新
+	// イベントデータからサブスクリプションを取得
+	var subscription stripe.Subscription
+	if err := json.Unmarshal(event.Data.Raw, &subscription); err != nil {
+		return fmt.Errorf("サブスクリプションのパースに失敗: %w", err)
+	}
 
-	if err := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); err != nil {
-		return fmt.Errorf("イベントスキップのマークに失敗: %w", err)
+	// サブスクリプションにアイテムが含まれていない場合はスキップ
+	if subscription.Items == nil || len(subscription.Items.Data) == 0 {
+		slog.InfoContext(ctx, "サブスクリプションにアイテムが含まれていないためスキップ",
+			"stripe_event_id", event.ID,
+			"subscription_id", subscription.ID,
+		)
+		if err := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); err != nil {
+			return fmt.Errorf("イベントスキップのマークに失敗: %w", err)
+		}
+		return nil
+	}
+
+	// 価格IDと請求期間を取得（最初のアイテムから）
+	item := subscription.Items.Data[0]
+
+	// StripeSubscriberを更新
+	input := usecase.UpdateStripeSubscriberInput{
+		StripeSubscriptionID:     subscription.ID,
+		StripePriceID:            item.Price.ID,
+		StripeStatus:             string(subscription.Status),
+		StripeCurrentPeriodStart: time.Unix(item.CurrentPeriodStart, 0),
+		StripeCurrentPeriodEnd:   time.Unix(item.CurrentPeriodEnd, 0),
+		StripeCancelAt:           nullTimeFromUnix(subscription.CancelAt),
+		StripeCanceledAt:         nullTimeFromUnix(subscription.CanceledAt),
+	}
+
+	result, err := h.updateStripeSubscriberUC.Execute(ctx, input)
+	if err != nil {
+		// サブスクリプションが見つからない場合はスキップ
+		if err == sql.ErrNoRows {
+			slog.WarnContext(ctx, "対応するStripeSubscriberが見つからないためスキップ",
+				"stripe_event_id", event.ID,
+				"subscription_id", subscription.ID,
+			)
+			if markErr := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); markErr != nil {
+				return fmt.Errorf("イベントスキップのマークに失敗: %w", markErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("StripeSubscriber更新に失敗: %w", err)
+	}
+
+	slog.InfoContext(ctx, "StripeSubscriberを更新しました",
+		"stripe_event_id", event.ID,
+		"stripe_subscriber_id", result.StripeSubscriber.ID,
+		"new_status", subscription.Status,
+	)
+
+	// 処理完了としてマーク
+	if err := h.stripeWebhookEventRepo.MarkAsProcessed(ctx, webhookEventID); err != nil {
+		return fmt.Errorf("イベント処理完了のマークに失敗: %w", err)
 	}
 
 	return nil
 }
 
 // handleCustomerSubscriptionDeleted はcustomer.subscription.deletedイベントを処理します
-// タスク3-3で実装予定
 func (h *Handler) handleCustomerSubscriptionDeleted(ctx context.Context, event *stripe.Event, webhookEventID int64) error {
-	slog.InfoContext(ctx, "customer.subscription.deletedイベントを受信（未実装）",
+	slog.InfoContext(ctx, "customer.subscription.deletedイベントを受信",
 		"stripe_event_id", event.ID,
 	)
 
-	// TODO: タスク3-3で実装
-	// - サブスクリプションの終了処理
-	// - Userとの紐付け解除
+	// イベントデータからサブスクリプションを取得
+	var subscription stripe.Subscription
+	if err := json.Unmarshal(event.Data.Raw, &subscription); err != nil {
+		return fmt.Errorf("サブスクリプションのパースに失敗: %w", err)
+	}
 
-	if err := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); err != nil {
-		return fmt.Errorf("イベントスキップのマークに失敗: %w", err)
+	// StripeSubscriberを削除（ステータス更新＋ユーザー紐付け解除）
+	input := usecase.DeleteStripeSubscriberInput{
+		StripeSubscriptionID: subscription.ID,
+		StripeCanceledAt:     time.Unix(subscription.CanceledAt, 0),
+	}
+
+	result, err := h.updateStripeSubscriberUC.ExecuteDelete(ctx, input)
+	if err != nil {
+		// サブスクリプションが見つからない場合はスキップ
+		if err == sql.ErrNoRows {
+			slog.WarnContext(ctx, "対応するStripeSubscriberが見つからないためスキップ",
+				"stripe_event_id", event.ID,
+				"subscription_id", subscription.ID,
+			)
+			if markErr := h.stripeWebhookEventRepo.MarkAsSkipped(ctx, webhookEventID); markErr != nil {
+				return fmt.Errorf("イベントスキップのマークに失敗: %w", markErr)
+			}
+			return nil
+		}
+		return fmt.Errorf("StripeSubscriber削除処理に失敗: %w", err)
+	}
+
+	logFields := []any{
+		"stripe_event_id", event.ID,
+		"stripe_subscriber_id", result.StripeSubscriber.ID,
+	}
+	if result.UserID != nil {
+		logFields = append(logFields, "unlinked_user_id", *result.UserID)
+	}
+	slog.InfoContext(ctx, "StripeSubscriberを削除しました", logFields...)
+
+	// 処理完了としてマーク
+	if err := h.stripeWebhookEventRepo.MarkAsProcessed(ctx, webhookEventID); err != nil {
+		return fmt.Errorf("イベント処理完了のマークに失敗: %w", err)
 	}
 
 	return nil
+}
+
+// nullTimeFromUnix はUnixタイムスタンプからsql.NullTimeを作成します
+// 値が0の場合はValidがfalseになります
+func nullTimeFromUnix(ts int64) sql.NullTime {
+	if ts == 0 {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{
+		Time:  time.Unix(ts, 0),
+		Valid: true,
+	}
 }

--- a/go/internal/handler/webhooks/stripe/create.go
+++ b/go/internal/handler/webhooks/stripe/create.go
@@ -16,6 +16,7 @@ import (
 	"github.com/annict/annict/go/internal/model"
 	"github.com/annict/annict/go/internal/repository"
 	annictSentry "github.com/annict/annict/go/internal/sentry"
+	annictstripe "github.com/annict/annict/go/internal/stripe"
 	"github.com/annict/annict/go/internal/usecase"
 )
 
@@ -268,8 +269,8 @@ func (h *Handler) handleCustomerSubscriptionUpdated(ctx context.Context, event *
 		StripeStatus:             string(subscription.Status),
 		StripeCurrentPeriodStart: time.Unix(item.CurrentPeriodStart, 0),
 		StripeCurrentPeriodEnd:   time.Unix(item.CurrentPeriodEnd, 0),
-		StripeCancelAt:           nullTimeFromUnix(subscription.CancelAt),
-		StripeCanceledAt:         nullTimeFromUnix(subscription.CanceledAt),
+		StripeCancelAt:           annictstripe.NullTimeFromUnix(subscription.CancelAt),
+		StripeCanceledAt:         annictstripe.NullTimeFromUnix(subscription.CanceledAt),
 	}
 
 	result, err := h.updateStripeSubscriberUC.Execute(ctx, input)
@@ -351,16 +352,4 @@ func (h *Handler) handleCustomerSubscriptionDeleted(ctx context.Context, event *
 	}
 
 	return nil
-}
-
-// nullTimeFromUnix はUnixタイムスタンプからsql.NullTimeを作成します
-// 値が0の場合はValidがfalseになります
-func nullTimeFromUnix(ts int64) sql.NullTime {
-	if ts == 0 {
-		return sql.NullTime{}
-	}
-	return sql.NullTime{
-		Time:  time.Unix(ts, 0),
-		Valid: true,
-	}
 }

--- a/go/internal/handler/webhooks/stripe/create_test.go
+++ b/go/internal/handler/webhooks/stripe/create_test.go
@@ -47,9 +47,10 @@ func TestCreate_SignatureValidation(t *testing.T) {
 
 	// UseCaseの作成
 	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 
 	// ハンドラーの作成
-	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC)
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC)
 
 	tests := []struct {
 		name           string
@@ -146,9 +147,10 @@ func TestCreate_Idempotency(t *testing.T) {
 
 	// UseCaseの作成
 	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 
 	// ハンドラーの作成
-	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC)
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC)
 
 	// 既にイベントを登録
 	existingEventID := "evt_existing_event_123"
@@ -207,9 +209,10 @@ func TestCreate_EventProcessing(t *testing.T) {
 
 	// UseCaseの作成
 	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 
 	// ハンドラーの作成
-	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC)
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC)
 
 	tests := []struct {
 		name           string

--- a/go/internal/handler/webhooks/stripe/create_test.go
+++ b/go/internal/handler/webhooks/stripe/create_test.go
@@ -48,9 +48,10 @@ func TestCreate_SignatureValidation(t *testing.T) {
 	// UseCaseの作成
 	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	deleteStripeSubscriberUC := usecase.NewDeleteStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 
 	// ハンドラーの作成
-	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC)
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC, deleteStripeSubscriberUC)
 
 	tests := []struct {
 		name           string
@@ -148,9 +149,10 @@ func TestCreate_Idempotency(t *testing.T) {
 	// UseCaseの作成
 	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	deleteStripeSubscriberUC := usecase.NewDeleteStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 
 	// ハンドラーの作成
-	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC)
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC, deleteStripeSubscriberUC)
 
 	// 既にイベントを登録
 	existingEventID := "evt_existing_event_123"
@@ -210,9 +212,10 @@ func TestCreate_EventProcessing(t *testing.T) {
 	// UseCaseの作成
 	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	deleteStripeSubscriberUC := usecase.NewDeleteStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 
 	// ハンドラーの作成
-	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC)
+	handler := NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC, deleteStripeSubscriberUC)
 
 	tests := []struct {
 		name           string

--- a/go/internal/handler/webhooks/stripe/handler.go
+++ b/go/internal/handler/webhooks/stripe/handler.go
@@ -15,6 +15,7 @@ type Handler struct {
 	userRepo                 *repository.UserRepository
 	createStripeSubscriberUC *usecase.CreateStripeSubscriberUsecase
 	updateStripeSubscriberUC *usecase.UpdateStripeSubscriberUsecase
+	deleteStripeSubscriberUC *usecase.DeleteStripeSubscriberUsecase
 }
 
 // NewHandler は新しいHandlerを作成します
@@ -25,6 +26,7 @@ func NewHandler(
 	userRepo *repository.UserRepository,
 	createStripeSubscriberUC *usecase.CreateStripeSubscriberUsecase,
 	updateStripeSubscriberUC *usecase.UpdateStripeSubscriberUsecase,
+	deleteStripeSubscriberUC *usecase.DeleteStripeSubscriberUsecase,
 ) *Handler {
 	return &Handler{
 		cfg:                      cfg,
@@ -33,5 +35,6 @@ func NewHandler(
 		userRepo:                 userRepo,
 		createStripeSubscriberUC: createStripeSubscriberUC,
 		updateStripeSubscriberUC: updateStripeSubscriberUC,
+		deleteStripeSubscriberUC: deleteStripeSubscriberUC,
 	}
 }

--- a/go/internal/handler/webhooks/stripe/handler.go
+++ b/go/internal/handler/webhooks/stripe/handler.go
@@ -14,6 +14,7 @@ type Handler struct {
 	stripeSubscriberRepo     *repository.StripeSubscriberRepository
 	userRepo                 *repository.UserRepository
 	createStripeSubscriberUC *usecase.CreateStripeSubscriberUsecase
+	updateStripeSubscriberUC *usecase.UpdateStripeSubscriberUsecase
 }
 
 // NewHandler は新しいHandlerを作成します
@@ -23,6 +24,7 @@ func NewHandler(
 	stripeSubscriberRepo *repository.StripeSubscriberRepository,
 	userRepo *repository.UserRepository,
 	createStripeSubscriberUC *usecase.CreateStripeSubscriberUsecase,
+	updateStripeSubscriberUC *usecase.UpdateStripeSubscriberUsecase,
 ) *Handler {
 	return &Handler{
 		cfg:                      cfg,
@@ -30,5 +32,6 @@ func NewHandler(
 		stripeSubscriberRepo:     stripeSubscriberRepo,
 		userRepo:                 userRepo,
 		createStripeSubscriberUC: createStripeSubscriberUC,
+		updateStripeSubscriberUC: updateStripeSubscriberUC,
 	}
 }

--- a/go/internal/repository/user.go
+++ b/go/internal/repository/user.go
@@ -61,6 +61,19 @@ func (r *UserRepository) GetByStripeSubscriberID(ctx context.Context, stripeSubs
 	return r.queries.GetUserByStripeSubscriberID(ctx, sql.NullInt64{Int64: stripeSubscriberID, Valid: true})
 }
 
+// FindUserIDByStripeSubscriberID はStripeサブスクライバーIDからユーザーIDを検索します
+// ユーザーが見つからない場合はnilを返します（sql.ErrNoRowsの場合）
+func (r *UserRepository) FindUserIDByStripeSubscriberID(ctx context.Context, stripeSubscriberID int64) (*int64, error) {
+	user, err := r.queries.GetUserByStripeSubscriberID(ctx, sql.NullInt64{Int64: stripeSubscriberID, Valid: true})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &user.ID, nil
+}
+
 // WithStripeSubscriberRepo はStripeSubscriberRepositoryを設定します
 func (r *UserRepository) WithStripeSubscriberRepo(repo *StripeSubscriberRepository) *UserRepository {
 	r.stripeSubscriberRepo = repo

--- a/go/internal/stripe/time.go
+++ b/go/internal/stripe/time.go
@@ -1,0 +1,18 @@
+package stripe
+
+import (
+	"database/sql"
+	"time"
+)
+
+// NullTimeFromUnix はUnixタイムスタンプからsql.NullTimeを作成します
+// 値が0の場合はValidがfalseになります
+func NullTimeFromUnix(ts int64) sql.NullTime {
+	if ts == 0 {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{
+		Time:  time.Unix(ts, 0),
+		Valid: true,
+	}
+}

--- a/go/internal/stripe/time_test.go
+++ b/go/internal/stripe/time_test.go
@@ -1,0 +1,47 @@
+package stripe
+
+import (
+	"testing"
+)
+
+func TestNullTimeFromUnix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		timestamp int64
+		wantValid bool
+	}{
+		{
+			name:      "0の場合はValidがfalse",
+			timestamp: 0,
+			wantValid: false,
+		},
+		{
+			name:      "正の値の場合はValidがtrue",
+			timestamp: 1609459200, // 2021-01-01 00:00:00 UTC
+			wantValid: true,
+		},
+		{
+			name:      "負の値の場合もValidがtrue",
+			timestamp: -1,
+			wantValid: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := NullTimeFromUnix(tt.timestamp)
+
+			if result.Valid != tt.wantValid {
+				t.Errorf("Valid: got %v, want %v", result.Valid, tt.wantValid)
+			}
+
+			if tt.wantValid && result.Time.Unix() != tt.timestamp {
+				t.Errorf("Time.Unix(): got %d, want %d", result.Time.Unix(), tt.timestamp)
+			}
+		})
+	}
+}

--- a/go/internal/testutil/fixtures.go
+++ b/go/internal/testutil/fixtures.go
@@ -170,12 +170,13 @@ func (b *EpisodeBuilder) Build() int64 {
 
 // UserBuilder はユーザーテストデータのビルダー
 type UserBuilder struct {
-	tx                *sql.Tx
-	t                 *testing.T
-	username          string
-	email             string
-	encryptedPassword string
-	locale            string
+	tx                 *sql.Tx
+	t                  *testing.T
+	username           string
+	email              string
+	encryptedPassword  string
+	locale             string
+	stripeSubscriberID *int64
 }
 
 // NewUserBuilder は新しいUserBuilderを作成します
@@ -216,6 +217,12 @@ func (b *UserBuilder) WithEncryptedPassword(password string) *UserBuilder {
 // WithLocale はロケールを設定します
 func (b *UserBuilder) WithLocale(locale string) *UserBuilder {
 	b.locale = locale
+	return b
+}
+
+// WithStripeSubscriberID はStripeサブスクライバーIDを設定します
+func (b *UserBuilder) WithStripeSubscriberID(id *int64) *UserBuilder {
+	b.stripeSubscriberID = id
 	return b
 }
 
@@ -315,7 +322,41 @@ func (b *UserBuilder) Build() int64 {
 		b.t.Fatalf("メール通知設定データの作成に失敗しました: %v", err)
 	}
 
+	// StripeSubscriberIDが設定されている場合は更新
+	if b.stripeSubscriberID != nil {
+		_, err = b.tx.Exec(`UPDATE users SET stripe_subscriber_id = $1 WHERE id = $2`, *b.stripeSubscriberID, id)
+		if err != nil {
+			b.t.Fatalf("ユーザーのStripeSubscriberID更新に失敗しました: %v", err)
+		}
+	}
+
 	return id
+}
+
+// UserResult はテスト用のユーザー結果
+type UserResult struct {
+	ID                 int64
+	Username           string
+	Email              string
+	StripeSubscriberID sql.NullInt64
+}
+
+// BuildWithResult はテスト用のユーザーデータをデータベースに作成し、結果を返します
+func (b *UserBuilder) BuildWithResult() UserResult {
+	b.t.Helper()
+	id := b.Build()
+
+	var stripeSubID sql.NullInt64
+	if b.stripeSubscriberID != nil {
+		stripeSubID = sql.NullInt64{Int64: *b.stripeSubscriberID, Valid: true}
+	}
+
+	return UserResult{
+		ID:                 id,
+		Username:           b.username,
+		Email:              b.email,
+		StripeSubscriberID: stripeSubID,
+	}
 }
 
 // WorkImageBuilder は作品画像テストデータのビルダー
@@ -574,11 +615,18 @@ func (b *StripeSubscriberBuilder) WithCanceledAt(canceledAt time.Time) *StripeSu
 	return b
 }
 
-// Build はテスト用のStripeサブスクライバーデータをデータベースに作成します
+// Build はテスト用のStripeサブスクライバーデータをデータベースに作成し、IDを返します
 func (b *StripeSubscriberBuilder) Build() int64 {
 	b.t.Helper()
+	result := b.BuildWithResult()
+	return result.ID
+}
 
-	query := `
+// BuildWithResult はテスト用のStripeサブスクライバーデータをデータベースに作成し、全フィールドを返します
+func (b *StripeSubscriberBuilder) BuildWithResult() StripeSubscriberResult {
+	b.t.Helper()
+
+	q := `
 		INSERT INTO stripe_subscribers (
 			stripe_customer_id,
 			stripe_subscription_id,
@@ -592,12 +640,15 @@ func (b *StripeSubscriberBuilder) Build() int64 {
 			updated_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10
-		) RETURNING id
+		) RETURNING id, stripe_customer_id, stripe_subscription_id, stripe_price_id, stripe_status,
+		            stripe_current_period_start, stripe_current_period_end, stripe_cancel_at, stripe_canceled_at,
+		            created_at, updated_at
 	`
 
-	var id int64
+	now := time.Now()
+	var result StripeSubscriberResult
 	err := b.tx.QueryRow(
-		query,
+		q,
 		b.stripeCustomerID,
 		b.stripeSubscriptionID,
 		b.stripePriceID,
@@ -606,15 +657,42 @@ func (b *StripeSubscriberBuilder) Build() int64 {
 		b.stripeCurrentPeriodEnd,
 		b.stripeCancelAt,
 		b.stripeCanceledAt,
-		time.Now(),
-		time.Now(),
-	).Scan(&id)
+		now,
+		now,
+	).Scan(
+		&result.ID,
+		&result.StripeCustomerID,
+		&result.StripeSubscriptionID,
+		&result.StripePriceID,
+		&result.StripeStatus,
+		&result.StripeCurrentPeriodStart,
+		&result.StripeCurrentPeriodEnd,
+		&result.StripeCancelAt,
+		&result.StripeCanceledAt,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	)
 
 	if err != nil {
 		b.t.Fatalf("Stripeサブスクライバーデータの作成に失敗しました: %v", err)
 	}
 
-	return id
+	return result
+}
+
+// StripeSubscriberResult はテスト用のStripeサブスクライバー結果
+type StripeSubscriberResult struct {
+	ID                       int64
+	StripeCustomerID         string
+	StripeSubscriptionID     string
+	StripePriceID            string
+	StripeStatus             string
+	StripeCurrentPeriodStart time.Time
+	StripeCurrentPeriodEnd   time.Time
+	StripeCancelAt           sql.NullTime
+	StripeCanceledAt         sql.NullTime
+	CreatedAt                time.Time
+	UpdatedAt                time.Time
 }
 
 // CreateTestStripeSubscriber は簡単にテスト用Stripeサブスクライバーを作成するヘルパー関数

--- a/go/internal/usecase/create_stripe_subscriber.go
+++ b/go/internal/usecase/create_stripe_subscriber.go
@@ -14,6 +14,7 @@ import (
 	"github.com/annict/annict/go/internal/model"
 	"github.com/annict/annict/go/internal/query"
 	"github.com/annict/annict/go/internal/repository"
+	annictstripe "github.com/annict/annict/go/internal/stripe"
 )
 
 // CreateStripeSubscriberUsecase はcheckout.session.completedイベント処理のユースケース
@@ -92,8 +93,8 @@ func (uc *CreateStripeSubscriberUsecase) Execute(
 		StripeStatus:             string(sub.Status),
 		StripeCurrentPeriodStart: time.Unix(item.CurrentPeriodStart, 0),
 		StripeCurrentPeriodEnd:   time.Unix(item.CurrentPeriodEnd, 0),
-		StripeCancelAt:           nullTimeFromUnix(sub.CancelAt),
-		StripeCanceledAt:         nullTimeFromUnix(sub.CanceledAt),
+		StripeCancelAt:           annictstripe.NullTimeFromUnix(sub.CancelAt),
+		StripeCanceledAt:         annictstripe.NullTimeFromUnix(sub.CanceledAt),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("StripeSubscriber作成に失敗: %w", err)
@@ -113,18 +114,6 @@ func (uc *CreateStripeSubscriberUsecase) Execute(
 	return &CreateStripeSubscriberResult{
 		StripeSubscriber: stripeSubscriber,
 	}, nil
-}
-
-// nullTimeFromUnix はUnixタイムスタンプからsql.NullTimeを作成します
-// 値が0の場合はValidがfalseになります
-func nullTimeFromUnix(ts int64) sql.NullTime {
-	if ts == 0 {
-		return sql.NullTime{}
-	}
-	return sql.NullTime{
-		Time:  time.Unix(ts, 0),
-		Valid: true,
-	}
 }
 
 // ParseUserIDFromMetadata はCheckoutセッションのmetadataからユーザーIDを取得します

--- a/go/internal/usecase/create_stripe_subscriber_test.go
+++ b/go/internal/usecase/create_stripe_subscriber_test.go
@@ -98,48 +98,6 @@ func TestParseUserIDFromMetadata(t *testing.T) {
 	}
 }
 
-func TestNullTimeFromUnix(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		timestamp int64
-		wantValid bool
-	}{
-		{
-			name:      "0の場合はValidがfalse",
-			timestamp: 0,
-			wantValid: false,
-		},
-		{
-			name:      "正の値の場合はValidがtrue",
-			timestamp: 1609459200, // 2021-01-01 00:00:00 UTC
-			wantValid: true,
-		},
-		{
-			name:      "負の値の場合もValidがtrue",
-			timestamp: -1,
-			wantValid: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			result := nullTimeFromUnix(tt.timestamp)
-
-			if result.Valid != tt.wantValid {
-				t.Errorf("Valid: got %v, want %v", result.Valid, tt.wantValid)
-			}
-
-			if tt.wantValid && result.Time.Unix() != tt.timestamp {
-				t.Errorf("Time.Unix(): got %d, want %d", result.Time.Unix(), tt.timestamp)
-			}
-		})
-	}
-}
-
 func TestInvalidSubscriptionStatusError(t *testing.T) {
 	t.Parallel()
 

--- a/go/internal/usecase/delete_stripe_subscriber.go
+++ b/go/internal/usecase/delete_stripe_subscriber.go
@@ -1,0 +1,116 @@
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/annict/annict/go/internal/model"
+	"github.com/annict/annict/go/internal/query"
+	"github.com/annict/annict/go/internal/repository"
+)
+
+// DeleteStripeSubscriberUsecase はサブスクリプション削除イベント処理のユースケース
+type DeleteStripeSubscriberUsecase struct {
+	db                   *sql.DB
+	stripeSubscriberRepo *repository.StripeSubscriberRepository
+	userRepo             *repository.UserRepository
+}
+
+// NewDeleteStripeSubscriberUsecase はDeleteStripeSubscriberUsecaseを作成します
+func NewDeleteStripeSubscriberUsecase(
+	db *sql.DB,
+	stripeSubscriberRepo *repository.StripeSubscriberRepository,
+	userRepo *repository.UserRepository,
+) *DeleteStripeSubscriberUsecase {
+	return &DeleteStripeSubscriberUsecase{
+		db:                   db,
+		stripeSubscriberRepo: stripeSubscriberRepo,
+		userRepo:             userRepo,
+	}
+}
+
+// DeleteStripeSubscriberInput はcustomer.subscription.deletedイベントの入力データ
+type DeleteStripeSubscriberInput struct {
+	StripeSubscriptionID string    // StripeのサブスクリプションID (sub_xxx)
+	StripeCanceledAt     time.Time // キャンセル日時
+}
+
+// DeleteStripeSubscriberResult はcustomer.subscription.deletedイベント処理の結果
+type DeleteStripeSubscriberResult struct {
+	StripeSubscriber query.StripeSubscriber
+	UserID           *int64 // 紐付け解除されたユーザーID（存在する場合）
+}
+
+// Execute はcustomer.subscription.deletedイベントを処理します
+//
+// 処理フロー:
+// 1. StripeサブスクリプションIDで既存レコードを検索
+// 2. ステータスをcanceledに更新
+// 3. Userとの紐付けを解除
+func (uc *DeleteStripeSubscriberUsecase) Execute(
+	ctx context.Context,
+	input DeleteStripeSubscriberInput,
+) (*DeleteStripeSubscriberResult, error) {
+	// 既存のStripeSubscriberを取得
+	subscriber, err := uc.stripeSubscriberRepo.GetByStripeSubscriptionID(ctx, input.StripeSubscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("StripeSubscriber取得に失敗: %w", err)
+	}
+
+	// トランザクション開始
+	tx, err := uc.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("トランザクション開始に失敗: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// ステータスをcanceledに更新
+	err = uc.stripeSubscriberRepo.Update(ctx, query.UpdateStripeSubscriberParams{
+		ID:                       subscriber.ID,
+		StripePriceID:            subscriber.StripePriceID,
+		StripeStatus:             string(model.StripeSubscriptionStatusCanceled),
+		StripeCurrentPeriodStart: subscriber.StripeCurrentPeriodStart,
+		StripeCurrentPeriodEnd:   subscriber.StripeCurrentPeriodEnd,
+		StripeCancelAt:           subscriber.StripeCancelAt,
+		StripeCanceledAt: sql.NullTime{
+			Time:  input.StripeCanceledAt,
+			Valid: true,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("StripeSubscriberステータス更新に失敗: %w", err)
+	}
+
+	// Userとの紐付けを解除
+	// StripeSubscriberIDが一致するユーザーを探してnilに設定
+	userID, err := uc.userRepo.FindUserIDByStripeSubscriberID(ctx, subscriber.ID)
+	if err != nil {
+		return nil, fmt.Errorf("ユーザー検索に失敗: %w", err)
+	}
+
+	if userID != nil {
+		// 紐付けを解除
+		err = uc.userRepo.UpdateStripeSubscriberID(ctx, *userID, nil)
+		if err != nil {
+			return nil, fmt.Errorf("ユーザー紐付け解除に失敗: %w", err)
+		}
+	}
+
+	// トランザクションコミット
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("トランザクションコミットに失敗: %w", err)
+	}
+
+	// 更新後のレコードを取得
+	updated, err := uc.stripeSubscriberRepo.GetByID(ctx, subscriber.ID)
+	if err != nil {
+		return nil, fmt.Errorf("更新後のStripeSubscriber取得に失敗: %w", err)
+	}
+
+	return &DeleteStripeSubscriberResult{
+		StripeSubscriber: updated,
+		UserID:           userID,
+	}, nil
+}

--- a/go/internal/usecase/delete_stripe_subscriber_test.go
+++ b/go/internal/usecase/delete_stripe_subscriber_test.go
@@ -1,0 +1,118 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/annict/annict/go/internal/model"
+	"github.com/annict/annict/go/internal/query"
+	"github.com/annict/annict/go/internal/repository"
+	"github.com/annict/annict/go/internal/testutil"
+)
+
+func TestDeleteStripeSubscriberUsecase_Execute(t *testing.T) {
+	t.Parallel()
+
+	// テストDBをセットアップ
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(tx)
+
+	// リポジトリの作成
+	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
+	userRepo := repository.NewUserRepository(queries)
+
+	// Usecaseの作成
+	uc := NewDeleteStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+
+	t.Run("サブスクリプションを削除できる", func(t *testing.T) {
+		// テスト用のStripeSubscriberを作成
+		subscriber := testutil.NewStripeSubscriberBuilder(t, tx).
+			WithStripeSubscriptionID("sub_test_delete_1").
+			WithStripeStatus("active").
+			BuildWithResult()
+
+		ctx := context.Background()
+		canceledAt := time.Now()
+
+		input := DeleteStripeSubscriberInput{
+			StripeSubscriptionID: subscriber.StripeSubscriptionID,
+			StripeCanceledAt:     canceledAt,
+		}
+
+		result, err := uc.Execute(ctx, input)
+		if err != nil {
+			t.Errorf("予期しないエラー: %v", err)
+			return
+		}
+
+		// ステータスがcanceledに更新されていることを確認
+		if result.StripeSubscriber.StripeStatus != string(model.StripeSubscriptionStatusCanceled) {
+			t.Errorf("StripeStatus: got %s, want %s", result.StripeSubscriber.StripeStatus, model.StripeSubscriptionStatusCanceled)
+		}
+
+		// キャンセル日時が設定されていることを確認
+		if !result.StripeSubscriber.StripeCanceledAt.Valid {
+			t.Error("StripeCanceledAt: Validがfalseですが、trueが期待されました")
+		}
+	})
+
+	t.Run("ユーザーとの紐付けが解除される", func(t *testing.T) {
+		// テスト用のStripeSubscriberを作成
+		subscriber := testutil.NewStripeSubscriberBuilder(t, tx).
+			WithStripeSubscriptionID("sub_test_delete_user_link").
+			WithStripeStatus("active").
+			BuildWithResult()
+
+		// テスト用のユーザーを作成してStripeSubscriberと紐付け
+		user := testutil.NewUserBuilder(t, tx).
+			WithStripeSubscriberID(&subscriber.ID).
+			BuildWithResult()
+
+		ctx := context.Background()
+
+		input := DeleteStripeSubscriberInput{
+			StripeSubscriptionID: subscriber.StripeSubscriptionID,
+			StripeCanceledAt:     time.Now(),
+		}
+
+		result, err := uc.Execute(ctx, input)
+		if err != nil {
+			t.Errorf("予期しないエラー: %v", err)
+			return
+		}
+
+		// ユーザーIDが返されていることを確認
+		if result.UserID == nil {
+			t.Error("UserID: nilが返されましたが、ユーザーIDが期待されました")
+			return
+		}
+		if *result.UserID != user.ID {
+			t.Errorf("UserID: got %d, want %d", *result.UserID, user.ID)
+		}
+
+		// ユーザーの紐付けが解除されていることを確認
+		updatedUser, err := userRepo.GetByID(ctx, user.ID)
+		if err != nil {
+			t.Errorf("ユーザー取得エラー: %v", err)
+			return
+		}
+		if updatedUser.StripeSubscriberID.Valid {
+			t.Errorf("StripeSubscriberID: 紐付けが解除されていません (値: %d)", updatedUser.StripeSubscriberID.Int64)
+		}
+	})
+
+	t.Run("存在しないサブスクリプションIDはエラー", func(t *testing.T) {
+		ctx := context.Background()
+
+		input := DeleteStripeSubscriberInput{
+			StripeSubscriptionID: "sub_nonexistent_delete",
+			StripeCanceledAt:     time.Now(),
+		}
+
+		_, err := uc.Execute(ctx, input)
+		if err == nil {
+			t.Error("エラーが期待されましたが、nilが返されました")
+		}
+	})
+}

--- a/go/internal/usecase/update_stripe_subscriber.go
+++ b/go/internal/usecase/update_stripe_subscriber.go
@@ -1,0 +1,179 @@
+// Package usecase はビジネスロジック層のユースケースを提供します
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/annict/annict/go/internal/model"
+	"github.com/annict/annict/go/internal/query"
+	"github.com/annict/annict/go/internal/repository"
+)
+
+// UpdateStripeSubscriberUsecase はサブスクリプション更新/削除イベント処理のユースケース
+type UpdateStripeSubscriberUsecase struct {
+	db                   *sql.DB
+	stripeSubscriberRepo *repository.StripeSubscriberRepository
+	userRepo             *repository.UserRepository
+}
+
+// NewUpdateStripeSubscriberUsecase はUpdateStripeSubscriberUsecaseを作成します
+func NewUpdateStripeSubscriberUsecase(
+	db *sql.DB,
+	stripeSubscriberRepo *repository.StripeSubscriberRepository,
+	userRepo *repository.UserRepository,
+) *UpdateStripeSubscriberUsecase {
+	return &UpdateStripeSubscriberUsecase{
+		db:                   db,
+		stripeSubscriberRepo: stripeSubscriberRepo,
+		userRepo:             userRepo,
+	}
+}
+
+// UpdateStripeSubscriberInput はcustomer.subscription.updatedイベントの入力データ
+type UpdateStripeSubscriberInput struct {
+	StripeSubscriptionID     string    // StripeのサブスクリプションID (sub_xxx)
+	StripePriceID            string    // Stripeの価格ID (price_xxx)
+	StripeStatus             string    // サブスクリプション状態 (active, canceled, etc.)
+	StripeCurrentPeriodStart time.Time // 現在の請求期間開始
+	StripeCurrentPeriodEnd   time.Time // 現在の請求期間終了
+	StripeCancelAt           sql.NullTime
+	StripeCanceledAt         sql.NullTime
+}
+
+// UpdateStripeSubscriberResult はcustomer.subscription.updatedイベント処理の結果
+type UpdateStripeSubscriberResult struct {
+	StripeSubscriber query.StripeSubscriber
+}
+
+// Execute はcustomer.subscription.updatedイベントを処理します
+//
+// 処理フロー:
+// 1. StripeサブスクリプションIDで既存レコードを検索
+// 2. サブスクリプション情報を更新
+func (uc *UpdateStripeSubscriberUsecase) Execute(
+	ctx context.Context,
+	input UpdateStripeSubscriberInput,
+) (*UpdateStripeSubscriberResult, error) {
+	// ステータスを検証
+	status := model.StripeSubscriptionStatus(input.StripeStatus)
+	if !status.IsValid() {
+		return nil, &InvalidSubscriptionStatusError{Status: input.StripeStatus}
+	}
+
+	// 既存のStripeSubscriberを取得
+	subscriber, err := uc.stripeSubscriberRepo.GetByStripeSubscriptionID(ctx, input.StripeSubscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("StripeSubscriber取得に失敗: %w", err)
+	}
+
+	// サブスクリプション情報を更新
+	err = uc.stripeSubscriberRepo.Update(ctx, query.UpdateStripeSubscriberParams{
+		ID:                       subscriber.ID,
+		StripePriceID:            input.StripePriceID,
+		StripeStatus:             input.StripeStatus,
+		StripeCurrentPeriodStart: input.StripeCurrentPeriodStart,
+		StripeCurrentPeriodEnd:   input.StripeCurrentPeriodEnd,
+		StripeCancelAt:           input.StripeCancelAt,
+		StripeCanceledAt:         input.StripeCanceledAt,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("StripeSubscriber更新に失敗: %w", err)
+	}
+
+	// 更新後のレコードを取得
+	updated, err := uc.stripeSubscriberRepo.GetByID(ctx, subscriber.ID)
+	if err != nil {
+		return nil, fmt.Errorf("更新後のStripeSubscriber取得に失敗: %w", err)
+	}
+
+	return &UpdateStripeSubscriberResult{
+		StripeSubscriber: updated,
+	}, nil
+}
+
+// DeleteStripeSubscriberInput はcustomer.subscription.deletedイベントの入力データ
+type DeleteStripeSubscriberInput struct {
+	StripeSubscriptionID string    // StripeのサブスクリプションID (sub_xxx)
+	StripeCanceledAt     time.Time // キャンセル日時
+}
+
+// DeleteStripeSubscriberResult はcustomer.subscription.deletedイベント処理の結果
+type DeleteStripeSubscriberResult struct {
+	StripeSubscriber query.StripeSubscriber
+	UserID           *int64 // 紐付け解除されたユーザーID（存在する場合）
+}
+
+// ExecuteDelete はcustomer.subscription.deletedイベントを処理します
+//
+// 処理フロー:
+// 1. StripeサブスクリプションIDで既存レコードを検索
+// 2. ステータスをcanceledに更新
+// 3. Userとの紐付けを解除
+func (uc *UpdateStripeSubscriberUsecase) ExecuteDelete(
+	ctx context.Context,
+	input DeleteStripeSubscriberInput,
+) (*DeleteStripeSubscriberResult, error) {
+	// 既存のStripeSubscriberを取得
+	subscriber, err := uc.stripeSubscriberRepo.GetByStripeSubscriptionID(ctx, input.StripeSubscriptionID)
+	if err != nil {
+		return nil, fmt.Errorf("StripeSubscriber取得に失敗: %w", err)
+	}
+
+	// トランザクション開始
+	tx, err := uc.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("トランザクション開始に失敗: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// ステータスをcanceledに更新
+	err = uc.stripeSubscriberRepo.Update(ctx, query.UpdateStripeSubscriberParams{
+		ID:                       subscriber.ID,
+		StripePriceID:            subscriber.StripePriceID,
+		StripeStatus:             string(model.StripeSubscriptionStatusCanceled),
+		StripeCurrentPeriodStart: subscriber.StripeCurrentPeriodStart,
+		StripeCurrentPeriodEnd:   subscriber.StripeCurrentPeriodEnd,
+		StripeCancelAt:           subscriber.StripeCancelAt,
+		StripeCanceledAt: sql.NullTime{
+			Time:  input.StripeCanceledAt,
+			Valid: true,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("StripeSubscriberステータス更新に失敗: %w", err)
+	}
+
+	// Userとの紐付けを解除
+	// StripeSubscriberIDが一致するユーザーを探してnilに設定
+	userID, err := uc.userRepo.FindUserIDByStripeSubscriberID(ctx, subscriber.ID)
+	if err != nil {
+		return nil, fmt.Errorf("ユーザー検索に失敗: %w", err)
+	}
+
+	if userID != nil {
+		// 紐付けを解除
+		err = uc.userRepo.UpdateStripeSubscriberID(ctx, *userID, nil)
+		if err != nil {
+			return nil, fmt.Errorf("ユーザー紐付け解除に失敗: %w", err)
+		}
+	}
+
+	// トランザクションコミット
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("トランザクションコミットに失敗: %w", err)
+	}
+
+	// 更新後のレコードを取得
+	updated, err := uc.stripeSubscriberRepo.GetByID(ctx, subscriber.ID)
+	if err != nil {
+		return nil, fmt.Errorf("更新後のStripeSubscriber取得に失敗: %w", err)
+	}
+
+	return &DeleteStripeSubscriberResult{
+		StripeSubscriber: updated,
+		UserID:           userID,
+	}, nil
+}

--- a/go/internal/usecase/update_stripe_subscriber.go
+++ b/go/internal/usecase/update_stripe_subscriber.go
@@ -12,7 +12,7 @@ import (
 	"github.com/annict/annict/go/internal/repository"
 )
 
-// UpdateStripeSubscriberUsecase はサブスクリプション更新/削除イベント処理のユースケース
+// UpdateStripeSubscriberUsecase はサブスクリプション更新イベント処理のユースケース
 type UpdateStripeSubscriberUsecase struct {
 	db                   *sql.DB
 	stripeSubscriberRepo *repository.StripeSubscriberRepository
@@ -91,89 +91,5 @@ func (uc *UpdateStripeSubscriberUsecase) Execute(
 
 	return &UpdateStripeSubscriberResult{
 		StripeSubscriber: updated,
-	}, nil
-}
-
-// DeleteStripeSubscriberInput はcustomer.subscription.deletedイベントの入力データ
-type DeleteStripeSubscriberInput struct {
-	StripeSubscriptionID string    // StripeのサブスクリプションID (sub_xxx)
-	StripeCanceledAt     time.Time // キャンセル日時
-}
-
-// DeleteStripeSubscriberResult はcustomer.subscription.deletedイベント処理の結果
-type DeleteStripeSubscriberResult struct {
-	StripeSubscriber query.StripeSubscriber
-	UserID           *int64 // 紐付け解除されたユーザーID（存在する場合）
-}
-
-// ExecuteDelete はcustomer.subscription.deletedイベントを処理します
-//
-// 処理フロー:
-// 1. StripeサブスクリプションIDで既存レコードを検索
-// 2. ステータスをcanceledに更新
-// 3. Userとの紐付けを解除
-func (uc *UpdateStripeSubscriberUsecase) ExecuteDelete(
-	ctx context.Context,
-	input DeleteStripeSubscriberInput,
-) (*DeleteStripeSubscriberResult, error) {
-	// 既存のStripeSubscriberを取得
-	subscriber, err := uc.stripeSubscriberRepo.GetByStripeSubscriptionID(ctx, input.StripeSubscriptionID)
-	if err != nil {
-		return nil, fmt.Errorf("StripeSubscriber取得に失敗: %w", err)
-	}
-
-	// トランザクション開始
-	tx, err := uc.db.BeginTx(ctx, nil)
-	if err != nil {
-		return nil, fmt.Errorf("トランザクション開始に失敗: %w", err)
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	// ステータスをcanceledに更新
-	err = uc.stripeSubscriberRepo.Update(ctx, query.UpdateStripeSubscriberParams{
-		ID:                       subscriber.ID,
-		StripePriceID:            subscriber.StripePriceID,
-		StripeStatus:             string(model.StripeSubscriptionStatusCanceled),
-		StripeCurrentPeriodStart: subscriber.StripeCurrentPeriodStart,
-		StripeCurrentPeriodEnd:   subscriber.StripeCurrentPeriodEnd,
-		StripeCancelAt:           subscriber.StripeCancelAt,
-		StripeCanceledAt: sql.NullTime{
-			Time:  input.StripeCanceledAt,
-			Valid: true,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("StripeSubscriberステータス更新に失敗: %w", err)
-	}
-
-	// Userとの紐付けを解除
-	// StripeSubscriberIDが一致するユーザーを探してnilに設定
-	userID, err := uc.userRepo.FindUserIDByStripeSubscriberID(ctx, subscriber.ID)
-	if err != nil {
-		return nil, fmt.Errorf("ユーザー検索に失敗: %w", err)
-	}
-
-	if userID != nil {
-		// 紐付けを解除
-		err = uc.userRepo.UpdateStripeSubscriberID(ctx, *userID, nil)
-		if err != nil {
-			return nil, fmt.Errorf("ユーザー紐付け解除に失敗: %w", err)
-		}
-	}
-
-	// トランザクションコミット
-	if err := tx.Commit(); err != nil {
-		return nil, fmt.Errorf("トランザクションコミットに失敗: %w", err)
-	}
-
-	// 更新後のレコードを取得
-	updated, err := uc.stripeSubscriberRepo.GetByID(ctx, subscriber.ID)
-	if err != nil {
-		return nil, fmt.Errorf("更新後のStripeSubscriber取得に失敗: %w", err)
-	}
-
-	return &DeleteStripeSubscriberResult{
-		StripeSubscriber: updated,
-		UserID:           userID,
 	}, nil
 }

--- a/go/internal/usecase/update_stripe_subscriber_test.go
+++ b/go/internal/usecase/update_stripe_subscriber_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/annict/annict/go/internal/model"
 	"github.com/annict/annict/go/internal/query"
 	"github.com/annict/annict/go/internal/repository"
 	"github.com/annict/annict/go/internal/testutil"
@@ -131,110 +130,4 @@ func TestUpdateStripeSubscriberUsecase_Execute(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestUpdateStripeSubscriberUsecase_ExecuteDelete(t *testing.T) {
-	t.Parallel()
-
-	// テストDBをセットアップ
-	db, tx := testutil.SetupTestDB(t)
-	queries := query.New(tx)
-
-	// リポジトリの作成
-	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
-	userRepo := repository.NewUserRepository(queries)
-
-	// Usecaseの作成
-	uc := NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
-
-	t.Run("サブスクリプションを削除できる", func(t *testing.T) {
-		// テスト用のStripeSubscriberを作成
-		subscriber := testutil.NewStripeSubscriberBuilder(t, tx).
-			WithStripeSubscriptionID("sub_test_delete_1").
-			WithStripeStatus("active").
-			BuildWithResult()
-
-		ctx := context.Background()
-		canceledAt := time.Now()
-
-		input := DeleteStripeSubscriberInput{
-			StripeSubscriptionID: subscriber.StripeSubscriptionID,
-			StripeCanceledAt:     canceledAt,
-		}
-
-		result, err := uc.ExecuteDelete(ctx, input)
-		if err != nil {
-			t.Errorf("予期しないエラー: %v", err)
-			return
-		}
-
-		// ステータスがcanceledに更新されていることを確認
-		if result.StripeSubscriber.StripeStatus != string(model.StripeSubscriptionStatusCanceled) {
-			t.Errorf("StripeStatus: got %s, want %s", result.StripeSubscriber.StripeStatus, model.StripeSubscriptionStatusCanceled)
-		}
-
-		// キャンセル日時が設定されていることを確認
-		if !result.StripeSubscriber.StripeCanceledAt.Valid {
-			t.Error("StripeCanceledAt: Validがfalseですが、trueが期待されました")
-		}
-	})
-
-	t.Run("ユーザーとの紐付けが解除される", func(t *testing.T) {
-		// テスト用のStripeSubscriberを作成
-		subscriber := testutil.NewStripeSubscriberBuilder(t, tx).
-			WithStripeSubscriptionID("sub_test_delete_user_link").
-			WithStripeStatus("active").
-			BuildWithResult()
-
-		// テスト用のユーザーを作成してStripeSubscriberと紐付け
-		user := testutil.NewUserBuilder(t, tx).
-			WithStripeSubscriberID(&subscriber.ID).
-			BuildWithResult()
-
-		ctx := context.Background()
-
-		input := DeleteStripeSubscriberInput{
-			StripeSubscriptionID: subscriber.StripeSubscriptionID,
-			StripeCanceledAt:     time.Now(),
-		}
-
-		result, err := uc.ExecuteDelete(ctx, input)
-		if err != nil {
-			t.Errorf("予期しないエラー: %v", err)
-			return
-		}
-
-		// ユーザーIDが返されていることを確認
-		if result.UserID == nil {
-			t.Error("UserID: nilが返されましたが、ユーザーIDが期待されました")
-			return
-		}
-		if *result.UserID != user.ID {
-			t.Errorf("UserID: got %d, want %d", *result.UserID, user.ID)
-		}
-
-		// ユーザーの紐付けが解除されていることを確認
-		updatedUser, err := userRepo.GetByID(ctx, user.ID)
-		if err != nil {
-			t.Errorf("ユーザー取得エラー: %v", err)
-			return
-		}
-		if updatedUser.StripeSubscriberID.Valid {
-			t.Errorf("StripeSubscriberID: 紐付けが解除されていません (値: %d)", updatedUser.StripeSubscriberID.Int64)
-		}
-	})
-
-	t.Run("存在しないサブスクリプションIDはエラー", func(t *testing.T) {
-		ctx := context.Background()
-
-		input := DeleteStripeSubscriberInput{
-			StripeSubscriptionID: "sub_nonexistent_delete",
-			StripeCanceledAt:     time.Now(),
-		}
-
-		_, err := uc.ExecuteDelete(ctx, input)
-		if err == nil {
-			t.Error("エラーが期待されましたが、nilが返されました")
-		}
-	})
 }

--- a/go/internal/usecase/update_stripe_subscriber_test.go
+++ b/go/internal/usecase/update_stripe_subscriber_test.go
@@ -1,0 +1,240 @@
+package usecase
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/annict/annict/go/internal/model"
+	"github.com/annict/annict/go/internal/query"
+	"github.com/annict/annict/go/internal/repository"
+	"github.com/annict/annict/go/internal/testutil"
+)
+
+func TestUpdateStripeSubscriberUsecase_Execute(t *testing.T) {
+	t.Parallel()
+
+	// テストDBをセットアップ
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(tx)
+
+	// リポジトリの作成
+	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
+	userRepo := repository.NewUserRepository(queries)
+
+	// テスト用のStripeSubscriberを作成
+	subscriber := testutil.NewStripeSubscriberBuilder(t, tx).
+		WithStripeSubscriptionID("sub_test_update_123").
+		WithStripeStatus("active").
+		WithStripePriceID("price_monthly").
+		BuildWithResult()
+
+	// Usecaseの作成
+	uc := NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+
+	tests := []struct {
+		name      string
+		input     UpdateStripeSubscriberInput
+		wantError bool
+	}{
+		{
+			name: "サブスクリプション状態を更新できる",
+			input: UpdateStripeSubscriberInput{
+				StripeSubscriptionID:     subscriber.StripeSubscriptionID,
+				StripePriceID:            "price_yearly",
+				StripeStatus:             "active",
+				StripeCurrentPeriodStart: time.Now(),
+				StripeCurrentPeriodEnd:   time.Now().AddDate(1, 0, 0),
+				StripeCancelAt:           sql.NullTime{},
+				StripeCanceledAt:         sql.NullTime{},
+			},
+			wantError: false,
+		},
+		{
+			name: "past_dueステータスに更新できる",
+			input: UpdateStripeSubscriberInput{
+				StripeSubscriptionID:     subscriber.StripeSubscriptionID,
+				StripePriceID:            "price_yearly",
+				StripeStatus:             "past_due",
+				StripeCurrentPeriodStart: time.Now(),
+				StripeCurrentPeriodEnd:   time.Now().AddDate(0, 1, 0),
+				StripeCancelAt:           sql.NullTime{},
+				StripeCanceledAt:         sql.NullTime{},
+			},
+			wantError: false,
+		},
+		{
+			name: "キャンセル予定日を設定できる",
+			input: UpdateStripeSubscriberInput{
+				StripeSubscriptionID:     subscriber.StripeSubscriptionID,
+				StripePriceID:            "price_monthly",
+				StripeStatus:             "active",
+				StripeCurrentPeriodStart: time.Now(),
+				StripeCurrentPeriodEnd:   time.Now().AddDate(0, 1, 0),
+				StripeCancelAt: sql.NullTime{
+					Time:  time.Now().AddDate(0, 1, 0),
+					Valid: true,
+				},
+				StripeCanceledAt: sql.NullTime{},
+			},
+			wantError: false,
+		},
+		{
+			name: "存在しないサブスクリプションIDはエラー",
+			input: UpdateStripeSubscriberInput{
+				StripeSubscriptionID:     "sub_nonexistent",
+				StripePriceID:            "price_monthly",
+				StripeStatus:             "active",
+				StripeCurrentPeriodStart: time.Now(),
+				StripeCurrentPeriodEnd:   time.Now().AddDate(0, 1, 0),
+			},
+			wantError: true,
+		},
+		{
+			name: "無効なステータスはエラー",
+			input: UpdateStripeSubscriberInput{
+				StripeSubscriptionID:     subscriber.StripeSubscriptionID,
+				StripePriceID:            "price_monthly",
+				StripeStatus:             "invalid_status",
+				StripeCurrentPeriodStart: time.Now(),
+				StripeCurrentPeriodEnd:   time.Now().AddDate(0, 1, 0),
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			result, err := uc.Execute(ctx, tt.input)
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("エラーが期待されましたが、nilが返されました")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("予期しないエラー: %v", err)
+				return
+			}
+
+			// 更新後の値を確認
+			if result.StripeSubscriber.StripePriceID != tt.input.StripePriceID {
+				t.Errorf("StripePriceID: got %s, want %s", result.StripeSubscriber.StripePriceID, tt.input.StripePriceID)
+			}
+			if result.StripeSubscriber.StripeStatus != tt.input.StripeStatus {
+				t.Errorf("StripeStatus: got %s, want %s", result.StripeSubscriber.StripeStatus, tt.input.StripeStatus)
+			}
+		})
+	}
+}
+
+func TestUpdateStripeSubscriberUsecase_ExecuteDelete(t *testing.T) {
+	t.Parallel()
+
+	// テストDBをセットアップ
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(tx)
+
+	// リポジトリの作成
+	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
+	userRepo := repository.NewUserRepository(queries)
+
+	// Usecaseの作成
+	uc := NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+
+	t.Run("サブスクリプションを削除できる", func(t *testing.T) {
+		// テスト用のStripeSubscriberを作成
+		subscriber := testutil.NewStripeSubscriberBuilder(t, tx).
+			WithStripeSubscriptionID("sub_test_delete_1").
+			WithStripeStatus("active").
+			BuildWithResult()
+
+		ctx := context.Background()
+		canceledAt := time.Now()
+
+		input := DeleteStripeSubscriberInput{
+			StripeSubscriptionID: subscriber.StripeSubscriptionID,
+			StripeCanceledAt:     canceledAt,
+		}
+
+		result, err := uc.ExecuteDelete(ctx, input)
+		if err != nil {
+			t.Errorf("予期しないエラー: %v", err)
+			return
+		}
+
+		// ステータスがcanceledに更新されていることを確認
+		if result.StripeSubscriber.StripeStatus != string(model.StripeSubscriptionStatusCanceled) {
+			t.Errorf("StripeStatus: got %s, want %s", result.StripeSubscriber.StripeStatus, model.StripeSubscriptionStatusCanceled)
+		}
+
+		// キャンセル日時が設定されていることを確認
+		if !result.StripeSubscriber.StripeCanceledAt.Valid {
+			t.Error("StripeCanceledAt: Validがfalseですが、trueが期待されました")
+		}
+	})
+
+	t.Run("ユーザーとの紐付けが解除される", func(t *testing.T) {
+		// テスト用のStripeSubscriberを作成
+		subscriber := testutil.NewStripeSubscriberBuilder(t, tx).
+			WithStripeSubscriptionID("sub_test_delete_user_link").
+			WithStripeStatus("active").
+			BuildWithResult()
+
+		// テスト用のユーザーを作成してStripeSubscriberと紐付け
+		user := testutil.NewUserBuilder(t, tx).
+			WithStripeSubscriberID(&subscriber.ID).
+			BuildWithResult()
+
+		ctx := context.Background()
+
+		input := DeleteStripeSubscriberInput{
+			StripeSubscriptionID: subscriber.StripeSubscriptionID,
+			StripeCanceledAt:     time.Now(),
+		}
+
+		result, err := uc.ExecuteDelete(ctx, input)
+		if err != nil {
+			t.Errorf("予期しないエラー: %v", err)
+			return
+		}
+
+		// ユーザーIDが返されていることを確認
+		if result.UserID == nil {
+			t.Error("UserID: nilが返されましたが、ユーザーIDが期待されました")
+			return
+		}
+		if *result.UserID != user.ID {
+			t.Errorf("UserID: got %d, want %d", *result.UserID, user.ID)
+		}
+
+		// ユーザーの紐付けが解除されていることを確認
+		updatedUser, err := userRepo.GetByID(ctx, user.ID)
+		if err != nil {
+			t.Errorf("ユーザー取得エラー: %v", err)
+			return
+		}
+		if updatedUser.StripeSubscriberID.Valid {
+			t.Errorf("StripeSubscriberID: 紐付けが解除されていません (値: %d)", updatedUser.StripeSubscriberID.Int64)
+		}
+	})
+
+	t.Run("存在しないサブスクリプションIDはエラー", func(t *testing.T) {
+		ctx := context.Background()
+
+		input := DeleteStripeSubscriberInput{
+			StripeSubscriptionID: "sub_nonexistent_delete",
+			StripeCanceledAt:     time.Now(),
+		}
+
+		_, err := uc.ExecuteDelete(ctx, input)
+		if err == nil {
+			t.Error("エラーが期待されましたが、nilが返されました")
+		}
+	})
+}


### PR DESCRIPTION
- UpdateStripeSubscriberUsecaseを追加（サブスクリプション状態更新・削除処理）
- UserRepositoryにFindUserIDByStripeSubscriberIDを追加
- handleCustomerSubscriptionUpdated/Deletedをwebhookハンドラーに実装
- サブスクリプション削除時にユーザーとの紐付けを解除
- テストヘルパーにBuildWithResultメソッドを追加