### PR TITLE
Stripe Checkoutセッション作成機能を実装

### DIFF
--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/annict/annict/go/internal/repository"
 	annictSentry "github.com/annict/annict/go/internal/sentry"
 	"github.com/annict/annict/go/internal/session"
+	annictStripe "github.com/annict/annict/go/internal/stripe"
 	"github.com/annict/annict/go/internal/turnstile"
 	"github.com/annict/annict/go/internal/usecase"
 	"github.com/annict/annict/go/internal/worker"
@@ -325,7 +326,14 @@ func main() {
 	// サポーターページハンドラーの初期化
 	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
 	gumroadSubscriberRepo := repository.NewGumroadSubscriberRepository(queries)
-	supportersHandler := supporters.NewHandler(cfg, sessionManager, stripeSubscriberRepo, gumroadSubscriberRepo)
+	annictStripeCfg := &annictStripe.Config{
+		SecretKey:      cfg.StripeSecretKey,
+		PublishableKey: cfg.StripePublishableKey,
+		WebhookSecret:  cfg.StripeWebhookSecret,
+		PriceMonthlyID: cfg.StripePriceMonthlyID,
+		PriceYearlyID:  cfg.StripePriceYearlyID,
+	}
+	supportersHandler := supporters.NewHandler(cfg, sessionManager, stripeSubscriberRepo, gumroadSubscriberRepo, annictStripeCfg)
 
 	// Stripe Webhookハンドラーの初期化
 	stripeWebhookEventRepo := repository.NewStripeWebhookEventRepository(queries)
@@ -368,6 +376,7 @@ func main() {
 
 	// サポーターページ
 	r.Get("/supporters", supportersHandler.Show)
+	r.Post("/supporters/checkout", supportersHandler.Create)
 
 	// Stripe Webhook
 	r.Post("/webhooks/stripe", stripeWebhookHandler.Create)

--- a/go/internal/handler/supporters/checkout.go
+++ b/go/internal/handler/supporters/checkout.go
@@ -1,0 +1,132 @@
+package supporters
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/stripe/stripe-go/v84"
+	"github.com/stripe/stripe-go/v84/checkout/session"
+
+	"github.com/annict/annict/go/internal/i18n"
+	authMiddleware "github.com/annict/annict/go/internal/middleware"
+)
+
+// CheckoutRequest はCheckoutセッション作成のリクエストパラメータ
+type CheckoutRequest struct {
+	Plan string
+}
+
+// Validate はリクエストパラメータのバリデーションを行います
+func (r *CheckoutRequest) Validate() map[string]string {
+	errors := make(map[string]string)
+	if r.Plan != "monthly" && r.Plan != "yearly" {
+		errors["plan"] = "invalid_plan"
+	}
+	return errors
+}
+
+// Create POST /supporters/checkout - Stripe Checkoutセッションを作成
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// ログインユーザーの取得（認証必須）
+	user := authMiddleware.GetUserFromContext(ctx)
+	if user == nil {
+		http.Redirect(w, r, "/sign_in", http.StatusSeeOther)
+		return
+	}
+
+	// リクエストパラメータの解析
+	if err := r.ParseForm(); err != nil {
+		slog.ErrorContext(ctx, "フォームのパースに失敗しました", "error", err)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	req := &CheckoutRequest{
+		Plan: r.FormValue("plan"),
+	}
+
+	// バリデーション
+	if errs := req.Validate(); len(errs) > 0 {
+		slog.WarnContext(ctx, "バリデーションエラー", "errors", errs, "user_id", user.ID)
+		h.redirectWithError(w, r, ctx, "supporters_checkout_invalid_plan")
+		return
+	}
+
+	// 重複サブスクリプションチェック
+	// 1. ユーザーに紐づくstripe_subscriber_idが存在しアクティブな場合はエラーを返す
+	if user.StripeSubscriberID.Valid && h.stripeSubscriberRepo != nil {
+		stripeSubscriber, err := h.stripeSubscriberRepo.GetByID(ctx, user.StripeSubscriberID.Int64)
+		if err == nil {
+			if h.stripeSubscriberRepo.IsActive(&stripeSubscriber) {
+				slog.InfoContext(ctx, "既にアクティブなサブスクリプションが存在します", "user_id", user.ID, "stripe_subscriber_id", user.StripeSubscriberID.Int64)
+				h.redirectWithError(w, r, ctx, "supporters_checkout_already_active")
+				return
+			}
+		}
+	}
+
+	// 価格IDの決定
+	var priceID string
+	switch req.Plan {
+	case "monthly":
+		priceID = h.stripeCfg.PriceMonthlyID
+	case "yearly":
+		priceID = h.stripeCfg.PriceYearlyID
+	}
+
+	if priceID == "" {
+		slog.ErrorContext(ctx, "Stripe価格IDが設定されていません", "plan", req.Plan)
+		h.redirectWithError(w, r, ctx, "supporters_checkout_error")
+		return
+	}
+
+	// Stripe Checkoutセッションの作成
+	successURL := h.cfg.AppURL() + "/supporters?success=true"
+	cancelURL := h.cfg.AppURL() + "/supporters?canceled=true"
+
+	params := &stripe.CheckoutSessionParams{
+		Mode: stripe.String(string(stripe.CheckoutSessionModeSubscription)),
+		LineItems: []*stripe.CheckoutSessionLineItemParams{
+			{
+				Price:    stripe.String(priceID),
+				Quantity: stripe.Int64(1),
+			},
+		},
+		SuccessURL: stripe.String(successURL),
+		CancelURL:  stripe.String(cancelURL),
+		Metadata: map[string]string{
+			"user_id": strconv.FormatInt(user.ID, 10),
+		},
+	}
+
+	// ロケールの設定
+	locale := i18n.GetLocale(ctx)
+	if locale == "ja" {
+		params.Locale = stripe.String("ja")
+	} else {
+		params.Locale = stripe.String("en")
+	}
+
+	checkoutSession, err := session.New(params)
+	if err != nil {
+		slog.ErrorContext(ctx, "Stripe Checkoutセッションの作成に失敗しました", "error", err, "user_id", user.ID)
+		h.redirectWithError(w, r, ctx, "supporters_checkout_error")
+		return
+	}
+
+	slog.InfoContext(ctx, "Stripe Checkoutセッションを作成しました", "session_id", checkoutSession.ID, "user_id", user.ID, "plan", req.Plan)
+
+	// Stripe Checkoutページへリダイレクト
+	http.Redirect(w, r, checkoutSession.URL, http.StatusSeeOther)
+}
+
+// redirectWithError はエラーメッセージをフラッシュに設定してリダイレクトします
+func (h *Handler) redirectWithError(w http.ResponseWriter, r *http.Request, ctx context.Context, messageKey string) {
+	// フラッシュメッセージを設定（"error"タイプ）
+	_ = h.sessionManager.SetFlash(ctx, w, r, "error", i18n.T(ctx, messageKey))
+	http.Redirect(w, r, "/supporters", http.StatusSeeOther)
+}

--- a/go/internal/handler/supporters/checkout_test.go
+++ b/go/internal/handler/supporters/checkout_test.go
@@ -1,0 +1,318 @@
+package supporters
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/annict/annict/go/internal/config"
+	"github.com/annict/annict/go/internal/middleware"
+	"github.com/annict/annict/go/internal/query"
+	"github.com/annict/annict/go/internal/repository"
+	"github.com/annict/annict/go/internal/session"
+	annictStripe "github.com/annict/annict/go/internal/stripe"
+	"github.com/annict/annict/go/internal/testutil"
+)
+
+// setupCheckoutTestHandler はテスト用のハンドラーをセットアップします
+func setupCheckoutTestHandler(t *testing.T, tx *sql.Tx, db *sql.DB, stripeCfg *annictStripe.Config) *Handler {
+	t.Helper()
+
+	queries := query.New(db).WithTx(tx)
+	cfg := &config.Config{
+		Env:    "test",
+		Domain: "test.annict.com",
+	}
+
+	sessionRepo := repository.NewSessionRepository(queries)
+	sessionManager := session.NewManager(sessionRepo, cfg)
+	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
+	gumroadSubscriberRepo := repository.NewGumroadSubscriberRepository(queries)
+
+	return NewHandler(cfg, sessionManager, stripeSubscriberRepo, gumroadSubscriberRepo, stripeCfg)
+}
+
+// TestCreate_NotLoggedIn は未ログインユーザーがアクセスした場合のテスト
+func TestCreate_NotLoggedIn(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+
+	stripeCfg := &annictStripe.Config{
+		PriceMonthlyID: "price_monthly_test",
+		PriceYearlyID:  "price_yearly_test",
+	}
+	handler := setupCheckoutTestHandler(t, tx, db, stripeCfg)
+
+	form := url.Values{}
+	form.Set("plan", "monthly")
+
+	req := httptest.NewRequest("POST", "/supporters/checkout", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	// ログインページへリダイレクトされることを確認
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/sign_in" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/sign_in")
+	}
+}
+
+// TestCreate_InvalidPlan は無効なプランが選択された場合のテスト
+func TestCreate_InvalidPlan(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+
+	stripeCfg := &annictStripe.Config{
+		PriceMonthlyID: "price_monthly_test",
+		PriceYearlyID:  "price_yearly_test",
+	}
+	handler := setupCheckoutTestHandler(t, tx, db, stripeCfg)
+
+	// ユーザーを作成
+	userID := testutil.NewUserBuilder(t, tx).Build()
+	user := getUserByID(t, tx, userID)
+
+	testCases := []struct {
+		name string
+		plan string
+	}{
+		{"empty plan", ""},
+		{"invalid plan value", "invalid"},
+		{"weekly plan", "weekly"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			form := url.Values{}
+			form.Set("plan", tc.plan)
+
+			req := httptest.NewRequest("POST", "/supporters/checkout", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+			req = req.WithContext(ctx)
+			rr := httptest.NewRecorder()
+
+			handler.Create(rr, req)
+
+			// サポーターページへリダイレクトされることを確認
+			if rr.Code != http.StatusSeeOther {
+				t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+			}
+
+			location := rr.Header().Get("Location")
+			if location != "/supporters" {
+				t.Errorf("wrong redirect location: got %v want %v", location, "/supporters")
+			}
+		})
+	}
+}
+
+// TestCreate_AlreadyActiveSubscription は既にアクティブなサブスクリプションがある場合のテスト
+func TestCreate_AlreadyActiveSubscription(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+
+	stripeCfg := &annictStripe.Config{
+		PriceMonthlyID: "price_monthly_test",
+		PriceYearlyID:  "price_yearly_test",
+	}
+	handler := setupCheckoutTestHandler(t, tx, db, stripeCfg)
+
+	// アクティブなStripeサポーターを作成
+	userID, _ := createUserWithStripeSubscriber(t, tx, "active")
+	user := getUserByID(t, tx, userID)
+
+	form := url.Values{}
+	form.Set("plan", "monthly")
+
+	req := httptest.NewRequest("POST", "/supporters/checkout", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	// サポーターページへリダイレクトされることを確認
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/supporters" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/supporters")
+	}
+}
+
+// TestCreate_PastDueSubscriptionAllowsCheckout は支払い遅延中のサブスクリプションがあってもCheckoutを許可する
+func TestCreate_PastDueSubscriptionBlocksCheckout(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+
+	stripeCfg := &annictStripe.Config{
+		PriceMonthlyID: "price_monthly_test",
+		PriceYearlyID:  "price_yearly_test",
+	}
+	handler := setupCheckoutTestHandler(t, tx, db, stripeCfg)
+
+	// past_dueステータスのStripeサポーターを作成
+	userID, _ := createUserWithStripeSubscriber(t, tx, "past_due")
+	user := getUserByID(t, tx, userID)
+
+	form := url.Values{}
+	form.Set("plan", "monthly")
+
+	req := httptest.NewRequest("POST", "/supporters/checkout", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	// past_dueはアクティブとして扱われるため、リダイレクトされることを確認
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/supporters" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/supporters")
+	}
+}
+
+// TestCreate_CanceledSubscriptionAllowsCheckout はキャンセル済みサブスクリプションがある場合はCheckoutを許可する
+func TestCreate_CanceledSubscriptionAllowsCheckout(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+
+	stripeCfg := &annictStripe.Config{
+		PriceMonthlyID: "price_monthly_test",
+		PriceYearlyID:  "price_yearly_test",
+	}
+	handler := setupCheckoutTestHandler(t, tx, db, stripeCfg)
+
+	// canceledステータスのStripeサポーターを作成
+	userID, _ := createUserWithStripeSubscriber(t, tx, "canceled")
+	user := getUserByID(t, tx, userID)
+
+	form := url.Values{}
+	form.Set("plan", "monthly")
+
+	req := httptest.NewRequest("POST", "/supporters/checkout", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	// canceledは非アクティブなので、Stripe API呼び出しに進む
+	// Stripe APIが設定されていない場合はエラーになりリダイレクトされる
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+}
+
+// TestCreate_NoSubscriptionAtAll はサブスクリプションが全くない場合のテスト
+func TestCreate_NoSubscriptionAtAll(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+
+	stripeCfg := &annictStripe.Config{
+		PriceMonthlyID: "price_monthly_test",
+		PriceYearlyID:  "price_yearly_test",
+	}
+	handler := setupCheckoutTestHandler(t, tx, db, stripeCfg)
+
+	// サブスクリプションを持たないユーザーを作成
+	userID := testutil.NewUserBuilder(t, tx).Build()
+	user := getUserByID(t, tx, userID)
+
+	form := url.Values{}
+	form.Set("plan", "monthly")
+
+	req := httptest.NewRequest("POST", "/supporters/checkout", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	// サブスクリプションがないので、Stripe API呼び出しに進む
+	// Stripe APIが設定されていない場合はエラーになりリダイレクトされる
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+}
+
+// TestCheckoutRequest_Validate はリクエストバリデーションのテスト
+func TestCheckoutRequest_Validate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		plan        string
+		expectError bool
+	}{
+		{"monthly plan", "monthly", false},
+		{"yearly plan", "yearly", false},
+		{"empty plan", "", true},
+		{"invalid plan", "weekly", true},
+		{"uppercase plan", "MONTHLY", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &CheckoutRequest{Plan: tc.plan}
+			errors := req.Validate()
+
+			if tc.expectError && len(errors) == 0 {
+				t.Error("expected validation error but got none")
+			}
+			if !tc.expectError && len(errors) > 0 {
+				t.Errorf("expected no validation error but got: %v", errors)
+			}
+		})
+	}
+}
+
+// TestCreate_MissingPriceID は価格IDが設定されていない場合のテスト
+func TestCreate_MissingPriceID(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+
+	// 価格IDが設定されていない
+	stripeCfg := &annictStripe.Config{
+		PriceMonthlyID: "",
+		PriceYearlyID:  "",
+	}
+	handler := setupCheckoutTestHandler(t, tx, db, stripeCfg)
+
+	// ユーザーを作成
+	userID := testutil.NewUserBuilder(t, tx).Build()
+	user := getUserByID(t, tx, userID)
+
+	form := url.Values{}
+	form.Set("plan", "monthly")
+
+	req := httptest.NewRequest("POST", "/supporters/checkout", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	// 価格IDが設定されていないため、エラーでリダイレクト
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/supporters" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/supporters")
+	}
+}

--- a/go/internal/handler/supporters/handler.go
+++ b/go/internal/handler/supporters/handler.go
@@ -5,6 +5,7 @@ import (
 	"github.com/annict/annict/go/internal/config"
 	"github.com/annict/annict/go/internal/repository"
 	"github.com/annict/annict/go/internal/session"
+	annictStripe "github.com/annict/annict/go/internal/stripe"
 )
 
 // Handler はサポーター関連のHTTPハンドラーです
@@ -13,6 +14,7 @@ type Handler struct {
 	sessionManager        *session.Manager
 	stripeSubscriberRepo  *repository.StripeSubscriberRepository
 	gumroadSubscriberRepo *repository.GumroadSubscriberRepository
+	stripeCfg             *annictStripe.Config
 }
 
 // NewHandler は新しいHandlerを作成します
@@ -21,11 +23,13 @@ func NewHandler(
 	sessionManager *session.Manager,
 	stripeSubscriberRepo *repository.StripeSubscriberRepository,
 	gumroadSubscriberRepo *repository.GumroadSubscriberRepository,
+	stripeCfg *annictStripe.Config,
 ) *Handler {
 	return &Handler{
 		cfg:                   cfg,
 		sessionManager:        sessionManager,
 		stripeSubscriberRepo:  stripeSubscriberRepo,
 		gumroadSubscriberRepo: gumroadSubscriberRepo,
+		stripeCfg:             stripeCfg,
 	}
 }

--- a/go/internal/handler/supporters/show_test.go
+++ b/go/internal/handler/supporters/show_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/annict/annict/go/internal/query"
 	"github.com/annict/annict/go/internal/repository"
 	"github.com/annict/annict/go/internal/session"
+	annictStripe "github.com/annict/annict/go/internal/stripe"
 	"github.com/annict/annict/go/internal/testutil"
 )
 
@@ -31,7 +32,10 @@ func setupTestHandler(t *testing.T, tx *sql.Tx, db *sql.DB) *Handler {
 	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
 	gumroadSubscriberRepo := repository.NewGumroadSubscriberRepository(queries)
 
-	return NewHandler(cfg, sessionManager, stripeSubscriberRepo, gumroadSubscriberRepo)
+	// テスト用のStripe設定（テストではStripe APIを呼び出さないため空でOK）
+	stripeCfg := &annictStripe.Config{}
+
+	return NewHandler(cfg, sessionManager, stripeSubscriberRepo, gumroadSubscriberRepo, stripeCfg)
 }
 
 // createUserWithStripeSubscriber はStripeサブスクライバーを持つユーザーを作成します

--- a/go/internal/i18n/locales/en.toml
+++ b/go/internal/i18n/locales/en.toml
@@ -726,3 +726,16 @@ other = "Cancellation Date"
 [supporters_manage_button]
 description = "Manage button"
 other = "Manage Subscription"
+
+# Supporter Checkout
+[supporters_checkout_invalid_plan]
+description = "Invalid plan selection error"
+other = "Invalid plan selected"
+
+[supporters_checkout_already_active]
+description = "Already active subscription error"
+other = "You are already a supporter"
+
+[supporters_checkout_error]
+description = "Checkout processing error"
+other = "An error occurred during checkout. Please try again later."

--- a/go/internal/i18n/locales/ja.toml
+++ b/go/internal/i18n/locales/ja.toml
@@ -726,3 +726,16 @@ other = "終了予定日"
 [supporters_manage_button]
 description = "管理ボタン"
 other = "サブスクリプションを管理"
+
+# サポーターCheckout関連
+[supporters_checkout_invalid_plan]
+description = "無効なプラン選択エラー"
+other = "無効なプランが選択されました"
+
+[supporters_checkout_already_active]
+description = "既にアクティブなサブスクリプションが存在するエラー"
+other = "既にサポーター登録済みです"
+
+[supporters_checkout_error]
+description = "Checkout処理エラー"
+other = "決済処理中にエラーが発生しました。しばらくしてから再度お試しください。"


### PR DESCRIPTION
- POST /supporters/checkout エンドポイントを追加
- ログインチェック・プランバリデーション・重複サブスクリプション防止を実装
- Stripe Checkout Session API呼び出し（metadataにuser_idを含める）
- ロケール対応（日本語/英語）のCheckoutページを生成
- Handler構造体にStripe設定を追加
- テストを追加（8ケース）