### PR TITLE
Stripe Customer Portal連携機能を実装

### DIFF
--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -377,6 +377,7 @@ func main() {
 	// サポーターページ
 	r.Get("/supporters", supportersHandler.Show)
 	r.Post("/supporters/checkout", supportersHandler.Create)
+	r.Post("/supporters/portal", supportersHandler.Portal)
 
 	// Stripe Webhook
 	r.Post("/webhooks/stripe", stripeWebhookHandler.Create)

--- a/go/internal/handler/supporters/portal.go
+++ b/go/internal/handler/supporters/portal.go
@@ -1,0 +1,73 @@
+package supporters
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/stripe/stripe-go/v84"
+	portalsession "github.com/stripe/stripe-go/v84/billingportal/session"
+
+	"github.com/annict/annict/go/internal/i18n"
+	authMiddleware "github.com/annict/annict/go/internal/middleware"
+)
+
+// Portal POST /supporters/portal - Stripe Customer Portalへリダイレクト
+func (h *Handler) Portal(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// ログインユーザーの取得（認証必須）
+	user := authMiddleware.GetUserFromContext(ctx)
+	if user == nil {
+		http.Redirect(w, r, "/sign_in", http.StatusSeeOther)
+		return
+	}
+
+	// Stripeサポーターのみアクセス可能
+	if !user.StripeSubscriberID.Valid || h.stripeSubscriberRepo == nil {
+		slog.WarnContext(ctx, "Stripeサポーターではないユーザーがポータルにアクセスしようとしました", "user_id", user.ID)
+		h.redirectWithError(w, r, ctx, "supporters_portal_not_supporter")
+		return
+	}
+
+	stripeSubscriber, err := h.stripeSubscriberRepo.GetByID(ctx, user.StripeSubscriberID.Int64)
+	if err != nil {
+		slog.ErrorContext(ctx, "Stripeサブスクライバーの取得に失敗しました", "error", err, "user_id", user.ID)
+		h.redirectWithError(w, r, ctx, "supporters_portal_error")
+		return
+	}
+
+	// アクティブなサブスクリプションのみ許可
+	if !h.stripeSubscriberRepo.IsActive(&stripeSubscriber) {
+		slog.WarnContext(ctx, "非アクティブなサブスクリプションでポータルにアクセスしようとしました", "user_id", user.ID, "status", stripeSubscriber.StripeStatus)
+		h.redirectWithError(w, r, ctx, "supporters_portal_not_supporter")
+		return
+	}
+
+	// Stripe Customer Portal セッションを作成
+	returnURL := h.cfg.AppURL() + "/supporters"
+
+	params := &stripe.BillingPortalSessionParams{
+		Customer:  stripe.String(stripeSubscriber.StripeCustomerID),
+		ReturnURL: stripe.String(returnURL),
+	}
+
+	// ロケールの設定
+	locale := i18n.GetLocale(ctx)
+	if locale == "ja" {
+		params.Locale = stripe.String("ja")
+	} else {
+		params.Locale = stripe.String("en")
+	}
+
+	portalSession, err := portalsession.New(params)
+	if err != nil {
+		slog.ErrorContext(ctx, "Stripe Customer Portalセッションの作成に失敗しました", "error", err, "user_id", user.ID)
+		h.redirectWithError(w, r, ctx, "supporters_portal_error")
+		return
+	}
+
+	slog.InfoContext(ctx, "Stripe Customer Portalセッションを作成しました", "user_id", user.ID)
+
+	// Stripe Customer Portalページへリダイレクト
+	http.Redirect(w, r, portalSession.URL, http.StatusSeeOther)
+}

--- a/go/internal/handler/supporters/portal_test.go
+++ b/go/internal/handler/supporters/portal_test.go
@@ -1,0 +1,223 @@
+package supporters
+
+import (
+	"context"
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/annict/annict/go/internal/config"
+	"github.com/annict/annict/go/internal/middleware"
+	"github.com/annict/annict/go/internal/query"
+	"github.com/annict/annict/go/internal/repository"
+	"github.com/annict/annict/go/internal/session"
+	annictStripe "github.com/annict/annict/go/internal/stripe"
+	"github.com/annict/annict/go/internal/testutil"
+)
+
+// setupPortalTestHandler はテスト用のハンドラーをセットアップします
+func setupPortalTestHandler(t *testing.T, tx *sql.Tx, db *sql.DB) *Handler {
+	t.Helper()
+
+	queries := query.New(db).WithTx(tx)
+	cfg := &config.Config{
+		Env:    "test",
+		Domain: "test.annict.com",
+	}
+
+	sessionRepo := repository.NewSessionRepository(queries)
+	sessionManager := session.NewManager(sessionRepo, cfg)
+	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
+	gumroadSubscriberRepo := repository.NewGumroadSubscriberRepository(queries)
+
+	// テスト用のStripe設定（テストではStripe APIを呼び出さないため空でOK）
+	stripeCfg := &annictStripe.Config{}
+
+	return NewHandler(cfg, sessionManager, stripeSubscriberRepo, gumroadSubscriberRepo, stripeCfg)
+}
+
+// TestPortal_NotLoggedIn は未ログインユーザーがアクセスした場合のテスト
+func TestPortal_NotLoggedIn(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	handler := setupPortalTestHandler(t, tx, db)
+
+	req := httptest.NewRequest("POST", "/supporters/portal", nil)
+	rr := httptest.NewRecorder()
+
+	handler.Portal(rr, req)
+
+	// ログインページへリダイレクトされることを確認
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/sign_in" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/sign_in")
+	}
+}
+
+// TestPortal_NotSupporter は非サポーターユーザーがアクセスした場合のテスト
+func TestPortal_NotSupporter(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	handler := setupPortalTestHandler(t, tx, db)
+
+	// サブスクリプションを持たないユーザーを作成
+	userID := testutil.NewUserBuilder(t, tx).Build()
+	user := getUserByID(t, tx, userID)
+
+	req := httptest.NewRequest("POST", "/supporters/portal", nil)
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Portal(rr, req)
+
+	// サポーターページへリダイレクトされることを確認
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/supporters" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/supporters")
+	}
+}
+
+// TestPortal_CanceledSubscription はキャンセル済みサブスクリプションの場合のテスト
+func TestPortal_CanceledSubscription(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	handler := setupPortalTestHandler(t, tx, db)
+
+	// canceledステータスのStripeサポーターを作成
+	userID, _ := createUserWithStripeSubscriber(t, tx, "canceled")
+	user := getUserByID(t, tx, userID)
+
+	req := httptest.NewRequest("POST", "/supporters/portal", nil)
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Portal(rr, req)
+
+	// 非アクティブなのでサポーターページへリダイレクト
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/supporters" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/supporters")
+	}
+}
+
+// TestPortal_UnpaidSubscription はunpaidステータスの場合のテスト
+func TestPortal_UnpaidSubscription(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	handler := setupPortalTestHandler(t, tx, db)
+
+	// unpaidステータスのStripeサポーターを作成
+	userID, _ := createUserWithStripeSubscriber(t, tx, "unpaid")
+	user := getUserByID(t, tx, userID)
+
+	req := httptest.NewRequest("POST", "/supporters/portal", nil)
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Portal(rr, req)
+
+	// 非アクティブなのでサポーターページへリダイレクト
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/supporters" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/supporters")
+	}
+}
+
+// TestPortal_ActiveSubscription_StripeAPIError はアクティブなサブスクリプションでStripe API呼び出しがエラーの場合のテスト
+// 注: テスト環境ではStripe APIが設定されていないため、エラーが発生してリダイレクトされる
+func TestPortal_ActiveSubscription_StripeAPIError(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	handler := setupPortalTestHandler(t, tx, db)
+
+	// アクティブなStripeサポーターを作成
+	userID, _ := createUserWithStripeSubscriber(t, tx, "active")
+	user := getUserByID(t, tx, userID)
+
+	req := httptest.NewRequest("POST", "/supporters/portal", nil)
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Portal(rr, req)
+
+	// Stripe APIがテスト環境で設定されていないためエラーになり、リダイレクトされる
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/supporters" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/supporters")
+	}
+}
+
+// TestPortal_PastDueSubscription_StripeAPIError は支払い遅延中のサブスクリプションの場合のテスト
+// past_dueはアクティブとして扱われるため、Stripe APIを呼び出す
+func TestPortal_PastDueSubscription_StripeAPIError(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	handler := setupPortalTestHandler(t, tx, db)
+
+	// past_dueステータスのStripeサポーターを作成
+	userID, _ := createUserWithStripeSubscriber(t, tx, "past_due")
+	user := getUserByID(t, tx, userID)
+
+	req := httptest.NewRequest("POST", "/supporters/portal", nil)
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Portal(rr, req)
+
+	// past_dueはアクティブなのでStripe APIを呼び出すが、テスト環境ではエラーになる
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/supporters" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/supporters")
+	}
+}
+
+// TestPortal_GumroadSubscriber はGumroadサポーターがアクセスした場合のテスト
+func TestPortal_GumroadSubscriber(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	handler := setupPortalTestHandler(t, tx, db)
+
+	// アクティブなGumroadサポーターを作成（Stripeサブスクリプションなし）
+	userID, _ := createUserWithGumroadSubscriber(t, tx, false)
+	user := getUserByID(t, tx, userID)
+
+	req := httptest.NewRequest("POST", "/supporters/portal", nil)
+	ctx := context.WithValue(req.Context(), middleware.UserContextKey, user)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Portal(rr, req)
+
+	// Stripeサポーターではないのでサポーターページへリダイレクト
+	if rr.Code != http.StatusSeeOther {
+		t.Errorf("wrong status code: got %v want %v", rr.Code, http.StatusSeeOther)
+	}
+
+	location := rr.Header().Get("Location")
+	if location != "/supporters" {
+		t.Errorf("wrong redirect location: got %v want %v", location, "/supporters")
+	}
+}

--- a/go/internal/i18n/locales/en.toml
+++ b/go/internal/i18n/locales/en.toml
@@ -739,3 +739,12 @@ other = "You are already a supporter"
 [supporters_checkout_error]
 description = "Checkout processing error"
 other = "An error occurred during checkout. Please try again later."
+
+# Supporter portal related
+[supporters_portal_error]
+description = "Portal session creation error"
+other = "Failed to access the portal. Please try again later."
+
+[supporters_portal_not_supporter]
+description = "Non-supporter user tried to access the portal"
+other = "Only active supporters can access this page"

--- a/go/internal/i18n/locales/ja.toml
+++ b/go/internal/i18n/locales/ja.toml
@@ -739,3 +739,12 @@ other = "既にサポーター登録済みです"
 [supporters_checkout_error]
 description = "Checkout処理エラー"
 other = "決済処理中にエラーが発生しました。しばらくしてから再度お試しください。"
+
+# サポーターポータル関連
+[supporters_portal_error]
+description = "ポータルセッション作成エラー"
+other = "ポータルへのアクセスに失敗しました。しばらくしてから再度お試しください。"
+
+[supporters_portal_not_supporter]
+description = "サポーターでないユーザーがポータルにアクセスしようとした"
+other = "サポーター登録中のユーザーのみアクセスできます"


### PR DESCRIPTION
- internal/handler/supporters/portal.goを追加
  - POST /supporters/portal エンドポイント
  - Stripe Billing Portal Session APIを呼び出し
  - アクティブなStripeサポーターのみアクセス可能
  - ロケール対応（日本語/英語）
- テストファイル（portal_test.go）を追加
- 翻訳ファイルにエラーメッセージを追加