### PR TITLE
特定商取引法に基づく表記からGumroadを削除

### DIFF
--- a/rails/app/views/pages/legal.html.erb
+++ b/rails/app/views/pages/legal.html.erb
@@ -64,7 +64,7 @@
             お支払い方法
           </dt>
           <dd class="col-sm-9 mb-3">
-            決済サービス「Stripe」または「Gumroad」を利用したクレジットカード決済
+            決済サービス「Stripe」を利用したクレジットカード決済
           </dd>
           <dt class="col-sm-3">
             支払時期


### PR DESCRIPTION
お支払い方法の記載を「Stripe」または「Gumroad」から
「Stripe」のみに変更。