### PR TITLE
SessionRepositoryにDeleteSessionメソッドを追加

### DIFF
--- a/go/internal/query/querier.go
+++ b/go/internal/query/querier.go
@@ -29,6 +29,7 @@ type Querier interface {
 	CreateWorkImage(ctx context.Context, arg CreateWorkImageParams) (int64, error)
 	DeleteExpiredPasswordResetTokens(ctx context.Context, expiresAt time.Time) error
 	DeleteExpiredSignInCodes(ctx context.Context, expiresAt time.Time) error
+	DeleteSession(ctx context.Context, sessionID string) error
 	DeleteUnusedPasswordResetTokensByUserID(ctx context.Context, userID int64) error
 	GetActivityByID(ctx context.Context, id int64) (GetActivityByIDRow, error)
 	GetActivityGroupByID(ctx context.Context, id int64) (ActivityGroup, error)

--- a/go/internal/query/queries/sessions.sql
+++ b/go/internal/query/queries/sessions.sql
@@ -18,3 +18,7 @@ WHERE session_id = $1;
 UPDATE sessions
 SET updated_at = CLOCK_TIMESTAMP()
 WHERE session_id = $1;
+
+-- name: DeleteSession :exec
+DELETE FROM sessions
+WHERE session_id = $1;

--- a/go/internal/query/sessions.sql.go
+++ b/go/internal/query/sessions.sql.go
@@ -34,6 +34,16 @@ func (q *Queries) CreateSession(ctx context.Context, arg CreateSessionParams) (S
 	return i, err
 }
 
+const deleteSession = `-- name: DeleteSession :exec
+DELETE FROM sessions
+WHERE session_id = $1
+`
+
+func (q *Queries) DeleteSession(ctx context.Context, sessionID string) error {
+	_, err := q.db.ExecContext(ctx, deleteSession, sessionID)
+	return err
+}
+
 const getSessionByID = `-- name: GetSessionByID :one
 SELECT id, session_id, data, created_at, updated_at
 FROM sessions

--- a/go/internal/repository/session.go
+++ b/go/internal/repository/session.go
@@ -66,6 +66,12 @@ func (r *SessionRepository) CreateSession(ctx context.Context, sessionID string,
 	})
 }
 
+// DeleteSession はセッションを削除します
+func (r *SessionRepository) DeleteSession(ctx context.Context, sessionID string) error {
+	privateID := r.generatePrivateID(sessionID)
+	return r.queries.DeleteSession(ctx, privateID)
+}
+
 // generatePrivateID はpublic IDからprivate IDを生成
 // Rails/Rackの実装と互換性のある形式: "2::" + SHA256(publicID)
 func (r *SessionRepository) generatePrivateID(publicID string) string {

--- a/go/internal/repository/session_test.go
+++ b/go/internal/repository/session_test.go
@@ -308,3 +308,50 @@ func TestCreateSession_Success(t *testing.T) {
 		t.Errorf("DBのセッションIDが一致しません: got %v, want %v", fetchedSession.SessionID, privateID)
 	}
 }
+
+// TestDeleteSession_Success はセッションを正常に削除できることをテスト
+func TestDeleteSession_Success(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewSessionRepository(queries)
+
+	// テスト用セッションを作成
+	publicID := testutil.NewSessionBuilder(t, tx).
+		WithSessionID("test_delete_session_id").
+		WithUserID(1).
+		Build()
+
+	// セッションが存在することを確認
+	privateID := generatePrivateID(publicID)
+	_, err := queries.GetSessionByID(context.Background(), privateID)
+	if err != nil {
+		t.Fatalf("セッションの取得に失敗: %v", err)
+	}
+
+	// DeleteSessionを実行
+	err = repo.DeleteSession(context.Background(), publicID)
+	if err != nil {
+		t.Fatalf("DeleteSessionに失敗: %v", err)
+	}
+
+	// セッションが削除されたことを確認
+	_, err = queries.GetSessionByID(context.Background(), privateID)
+	if err == nil {
+		t.Error("削除したセッションがまだ存在しています")
+	}
+}
+
+// TestDeleteSession_NonExistent は存在しないセッションIDでもエラーが発生しないことをテスト
+func TestDeleteSession_NonExistent(t *testing.T) {
+	db, tx := testutil.SetupTestDB(t)
+	queries := query.New(db).WithTx(tx)
+	repo := repository.NewSessionRepository(queries)
+
+	// 存在しないセッションIDでDeleteSessionを実行
+	err := repo.DeleteSession(context.Background(), "non_existent_session_id")
+
+	// エラーが発生しないことを確認（DELETEは0行削除でもエラーにならない）
+	if err != nil {
+		t.Errorf("存在しないセッションIDでエラーが発生しました: %v", err)
+	}
+}


### PR DESCRIPTION
ログアウト機能実装の準備として、セッション削除機能を追加。

- sessions.sqlにDeleteSessionクエリを追加
- SessionRepositoryにDeleteSessionメソッドを追加
- 正常系・異常系のテストを追加