### PR TITLE
ログアウトハンドラーを実装

### DIFF
--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/annict/annict/go/internal/handler/sign_in"
 	"github.com/annict/annict/go/internal/handler/sign_in_code"
 	"github.com/annict/annict/go/internal/handler/sign_in_password"
+	"github.com/annict/annict/go/internal/handler/sign_out"
 	"github.com/annict/annict/go/internal/handler/sign_up"
 	"github.com/annict/annict/go/internal/handler/sign_up_code"
 	"github.com/annict/annict/go/internal/handler/sign_up_username"
@@ -311,6 +312,9 @@ func main() {
 	// パスワードログインハンドラーの初期化
 	signInPasswordHandler := sign_in_password.NewHandler(cfg, userRepo, sessionManager, createSessionUC)
 
+	// ログアウトハンドラーの初期化
+	signOutHandler := sign_out.NewHandler(sessionManager)
+
 	// パスワードリセット申請ハンドラーの初期化
 	createPasswordResetTokenUC := usecase.NewCreatePasswordResetTokenUsecase(db, queries, riverClient)
 	passwordResetHandler := password_reset.NewHandler(cfg, userRepo, sessionManager, limiter, turnstileClient, createPasswordResetTokenUC)
@@ -358,6 +362,8 @@ func main() {
 	r.Patch("/sign_in/code", signInCodeHandler.Update)
 	r.Get("/sign_in/password", signInPasswordHandler.New)
 	r.Post("/sign_in/password", signInPasswordHandler.Create)
+	r.Delete("/sign_out", signOutHandler.Delete) // Rails UJSからのDELETEリクエスト
+	r.Post("/sign_out", signOutHandler.Delete)   // Go版HTMLフォームからのPOST + _method=DELETE
 	r.Get("/sign_up", signUpHandler.New)
 	r.Post("/sign_up", signUpHandler.Create)
 	r.Get("/sign_up/code", signUpCodeHandler.New)

--- a/go/internal/handler/sign_out/delete.go
+++ b/go/internal/handler/sign_out/delete.go
@@ -1,0 +1,21 @@
+package sign_out
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+// Delete はログアウト処理を行います
+// DBからセッションレコードを削除し、Cookieをクリアしてホームページにリダイレクトします
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// セッションを削除（DBレコード削除 + Cookie削除）
+	if err := h.sessionMgr.DestroySession(ctx, w, r); err != nil {
+		slog.ErrorContext(ctx, "セッションの削除に失敗しました", "error", err)
+		// エラーが発生してもホームにリダイレクトする
+	}
+
+	// ホームページにリダイレクト
+	http.Redirect(w, r, "/", http.StatusFound)
+}

--- a/go/internal/handler/sign_out/delete_test.go
+++ b/go/internal/handler/sign_out/delete_test.go
@@ -1,0 +1,197 @@
+package sign_out
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/annict/annict/go/internal/config"
+	"github.com/annict/annict/go/internal/repository"
+	"github.com/annict/annict/go/internal/session"
+	"github.com/annict/annict/go/internal/testutil"
+)
+
+// setupSession はログイン状態をシミュレートするためのセッションを作成し、セッションCookieを返します
+func setupSession(t *testing.T, sessionMgr *session.Manager, userID int64) *http.Cookie {
+	t.Helper()
+
+	// ダミーリクエストとレスポンスを作成
+	req := httptest.NewRequest("GET", "/", nil)
+	rr := httptest.NewRecorder()
+	ctx := req.Context()
+
+	// ログインセッションを作成（userID付き）
+	if err := sessionMgr.CreateSession(ctx, rr, req, userID); err != nil {
+		t.Fatalf("セッションの作成に失敗: %v", err)
+	}
+
+	// 作成されたセッションCookieを取得
+	cookies := rr.Result().Cookies()
+	for _, cookie := range cookies {
+		if cookie.Name == session.SessionKey {
+			return cookie
+		}
+	}
+
+	t.Fatal("セッションCookieが作成されませんでした")
+	return nil
+}
+
+// TestDelete_WithSession セッションがある場合のログアウトテスト
+func TestDelete_WithSession(t *testing.T) {
+	t.Parallel()
+
+	db, tx := testutil.SetupTestDB(t)
+	queries := testutil.NewQueriesWithTx(db, tx)
+
+	// テストユーザーを作成
+	userID := testutil.NewUserBuilder(t, tx).
+		WithUsername("signout_test_user").
+		WithEmail("signout_test@example.com").
+		Build()
+
+	// 設定とセッションマネージャーを作成
+	cfg := &config.Config{
+		CookieDomain:    ".example.com",
+		SessionSecure:   "false",
+		SessionHTTPOnly: "true",
+	}
+	sessionRepo := repository.NewSessionRepository(queries)
+	sessionMgr := session.NewManager(sessionRepo, cfg)
+
+	handler := NewHandler(sessionMgr)
+
+	// ログインセッションを作成
+	sessionCookie := setupSession(t, sessionMgr, userID)
+
+	// DELETEリクエストを作成
+	req := httptest.NewRequest("DELETE", "/sign_out", nil)
+	req.AddCookie(sessionCookie)
+	rr := httptest.NewRecorder()
+
+	// ハンドラーを実行
+	handler.Delete(rr, req)
+
+	// ステータスコードを確認（リダイレクト）
+	if rr.Code != http.StatusFound {
+		t.Errorf("ステータスコードが正しくない: got %v want %v", rr.Code, http.StatusFound)
+	}
+
+	// リダイレクト先を確認
+	location := rr.Header().Get("Location")
+	if location != "/" {
+		t.Errorf("リダイレクト先が正しくない: got %v want %v", location, "/")
+	}
+
+	// セッションCookieが削除されているか確認（MaxAge=-1）
+	cookies := rr.Result().Cookies()
+	var newSessionCookie *http.Cookie
+	for _, cookie := range cookies {
+		if cookie.Name == session.SessionKey {
+			newSessionCookie = cookie
+			break
+		}
+	}
+
+	if newSessionCookie == nil {
+		t.Error("セッションCookie削除のレスポンスがありません")
+	} else {
+		if newSessionCookie.MaxAge != -1 {
+			t.Errorf("セッションCookieのMaxAgeが正しくない: got %v want %v", newSessionCookie.MaxAge, -1)
+		}
+	}
+
+	// DBからセッションが削除されていることを確認
+	sessionData, err := sessionMgr.GetSession(context.Background(), sessionCookie.Value)
+	if err != nil {
+		t.Fatalf("セッション取得エラー: %v", err)
+	}
+	if sessionData != nil {
+		t.Error("DBからセッションが削除されていません")
+	}
+}
+
+// TestDelete_WithoutSession セッションがない場合のログアウトテスト
+func TestDelete_WithoutSession(t *testing.T) {
+	t.Parallel()
+
+	db, tx := testutil.SetupTestDB(t)
+	queries := testutil.NewQueriesWithTx(db, tx)
+
+	// 設定とセッションマネージャーを作成
+	cfg := &config.Config{
+		CookieDomain:    ".example.com",
+		SessionSecure:   "false",
+		SessionHTTPOnly: "true",
+	}
+	sessionRepo := repository.NewSessionRepository(queries)
+	sessionMgr := session.NewManager(sessionRepo, cfg)
+
+	handler := NewHandler(sessionMgr)
+
+	// セッションなしでDELETEリクエストを作成
+	req := httptest.NewRequest("DELETE", "/sign_out", nil)
+	rr := httptest.NewRecorder()
+
+	// ハンドラーを実行
+	handler.Delete(rr, req)
+
+	// ステータスコードを確認（リダイレクト）
+	if rr.Code != http.StatusFound {
+		t.Errorf("ステータスコードが正しくない: got %v want %v", rr.Code, http.StatusFound)
+	}
+
+	// リダイレクト先を確認
+	location := rr.Header().Get("Location")
+	if location != "/" {
+		t.Errorf("リダイレクト先が正しくない: got %v want %v", location, "/")
+	}
+}
+
+// TestDelete_POSTMethod HTMLフォームからのPOSTリクエストでも動作することをテスト
+func TestDelete_POSTMethod(t *testing.T) {
+	t.Parallel()
+
+	db, tx := testutil.SetupTestDB(t)
+	queries := testutil.NewQueriesWithTx(db, tx)
+
+	// テストユーザーを作成
+	userID := testutil.NewUserBuilder(t, tx).
+		WithUsername("signout_post_user").
+		WithEmail("signout_post@example.com").
+		Build()
+
+	// 設定とセッションマネージャーを作成
+	cfg := &config.Config{
+		CookieDomain:    ".example.com",
+		SessionSecure:   "false",
+		SessionHTTPOnly: "true",
+	}
+	sessionRepo := repository.NewSessionRepository(queries)
+	sessionMgr := session.NewManager(sessionRepo, cfg)
+
+	handler := NewHandler(sessionMgr)
+
+	// ログインセッションを作成
+	sessionCookie := setupSession(t, sessionMgr, userID)
+
+	// POSTリクエストを作成（Method Override経由でDELETEに変換される前の状態）
+	req := httptest.NewRequest("POST", "/sign_out", nil)
+	req.AddCookie(sessionCookie)
+	rr := httptest.NewRecorder()
+
+	// ハンドラーを実行（直接呼び出し）
+	handler.Delete(rr, req)
+
+	// ステータスコードを確認（リダイレクト）
+	if rr.Code != http.StatusFound {
+		t.Errorf("ステータスコードが正しくない: got %v want %v", rr.Code, http.StatusFound)
+	}
+
+	// リダイレクト先を確認
+	location := rr.Header().Get("Location")
+	if location != "/" {
+		t.Errorf("リダイレクト先が正しくない: got %v want %v", location, "/")
+	}
+}

--- a/go/internal/handler/sign_out/handler.go
+++ b/go/internal/handler/sign_out/handler.go
@@ -1,0 +1,18 @@
+// Package sign_out はログアウト機能を提供します
+package sign_out
+
+import (
+	"github.com/annict/annict/go/internal/session"
+)
+
+// Handler はログアウト関連のHTTPハンドラーです
+type Handler struct {
+	sessionMgr *session.Manager
+}
+
+// NewHandler は新しいHandlerを作成します
+func NewHandler(sessionMgr *session.Manager) *Handler {
+	return &Handler{
+		sessionMgr: sessionMgr,
+	}
+}

--- a/go/internal/middleware/csrf.go
+++ b/go/internal/middleware/csrf.go
@@ -3,6 +3,7 @@ package middleware
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/annict/annict/go/internal/session"
 )
@@ -10,12 +11,17 @@ import (
 // CSRFMiddleware はCSRF保護ミドルウェア
 type CSRFMiddleware struct {
 	sessionManager *session.Manager
+	skipPaths      []string
 }
 
 // NewCSRFMiddleware は新しいCSRFミドルウェアを作成
 func NewCSRFMiddleware(sessionManager *session.Manager) *CSRFMiddleware {
 	return &CSRFMiddleware{
 		sessionManager: sessionManager,
+		skipPaths: []string{
+			"/webhooks/stripe", // Stripeは独自の署名検証を使用
+			"/sign_out",        // Rails版からのリクエスト対応のためCSRFを適用しない
+		},
 	}
 }
 
@@ -28,6 +34,14 @@ func (m *CSRFMiddleware) Middleware(next http.Handler) http.Handler {
 		if r.Method == "GET" || r.Method == "HEAD" || r.Method == "OPTIONS" {
 			next.ServeHTTP(w, r)
 			return
+		}
+
+		// スキップパスに一致する場合はCSRFチェックをスキップ
+		for _, path := range m.skipPaths {
+			if strings.HasPrefix(r.URL.Path, path) {
+				next.ServeHTTP(w, r)
+				return
+			}
 		}
 
 		// セッションIDを取得


### PR DESCRIPTION
- internal/handler/sign_out/にHandler構造体とDelete処理を追加
- CSRFミドルウェアに/sign_outのスキップパスを追加
- cmd/server/main.goにDELETEとPOST両方のルーティングを追加
- ハンドラーのテストを追加（セッションあり/なし、POSTメソッド）