### PR TITLE
Stripeクライアントを推奨パターンに移行

### DIFF
--- a/go/cmd/server/main.go
+++ b/go/cmd/server/main.go
@@ -337,11 +337,12 @@ func main() {
 		PriceMonthlyID: cfg.StripePriceMonthlyID,
 		PriceYearlyID:  cfg.StripePriceYearlyID,
 	}
-	supportersHandler := supporters.NewHandler(cfg, sessionManager, imageHelper, stripeSubscriberRepo, gumroadSubscriberRepo, annictStripeCfg)
+	stripeClient := annictStripe.NewClient(cfg.StripeSecretKey)
+	supportersHandler := supporters.NewHandler(cfg, sessionManager, imageHelper, stripeSubscriberRepo, gumroadSubscriberRepo, annictStripeCfg, stripeClient)
 
 	// Stripe Webhookハンドラーの初期化
 	stripeWebhookEventRepo := repository.NewStripeWebhookEventRepository(queries)
-	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo, stripeClient)
 	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 	deleteStripeSubscriberUC := usecase.NewDeleteStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 	stripeWebhookHandler := stripewebhook.NewHandler(cfg, stripeWebhookEventRepo, stripeSubscriberRepo, userRepo, createStripeSubscriberUC, updateStripeSubscriberUC, deleteStripeSubscriberUC)

--- a/go/internal/handler/supporters/checkout_test.go
+++ b/go/internal/handler/supporters/checkout_test.go
@@ -35,7 +35,8 @@ func setupCheckoutTestHandler(t *testing.T, tx *sql.Tx, db *sql.DB, stripeCfg *a
 	stripeSubscriberRepo := repository.NewStripeSubscriberRepository(queries)
 	gumroadSubscriberRepo := repository.NewGumroadSubscriberRepository(queries)
 
-	return NewHandler(cfg, sessionManager, imageHelper, stripeSubscriberRepo, gumroadSubscriberRepo, stripeCfg)
+	// テスト用には nil を渡す（テストでは Stripe API を呼び出さない）
+	return NewHandler(cfg, sessionManager, imageHelper, stripeSubscriberRepo, gumroadSubscriberRepo, stripeCfg, nil)
 }
 
 // TestCreate_NotLoggedIn は未ログインユーザーがアクセスした場合のテスト

--- a/go/internal/handler/supporters/handler.go
+++ b/go/internal/handler/supporters/handler.go
@@ -2,6 +2,8 @@
 package supporters
 
 import (
+	"github.com/stripe/stripe-go/v84"
+
 	"github.com/annict/annict/go/internal/config"
 	"github.com/annict/annict/go/internal/image"
 	"github.com/annict/annict/go/internal/repository"
@@ -17,6 +19,7 @@ type Handler struct {
 	stripeSubscriberRepo  *repository.StripeSubscriberRepository
 	gumroadSubscriberRepo *repository.GumroadSubscriberRepository
 	stripeCfg             *annictStripe.Config
+	stripeClient          *stripe.Client
 }
 
 // NewHandler は新しいHandlerを作成します
@@ -27,6 +30,7 @@ func NewHandler(
 	stripeSubscriberRepo *repository.StripeSubscriberRepository,
 	gumroadSubscriberRepo *repository.GumroadSubscriberRepository,
 	stripeCfg *annictStripe.Config,
+	stripeClient *stripe.Client,
 ) *Handler {
 	return &Handler{
 		cfg:                   cfg,
@@ -35,5 +39,6 @@ func NewHandler(
 		stripeSubscriberRepo:  stripeSubscriberRepo,
 		gumroadSubscriberRepo: gumroadSubscriberRepo,
 		stripeCfg:             stripeCfg,
+		stripeClient:          stripeClient,
 	}
 }

--- a/go/internal/handler/supporters/portal_test.go
+++ b/go/internal/handler/supporters/portal_test.go
@@ -36,7 +36,8 @@ func setupPortalTestHandler(t *testing.T, tx *sql.Tx, db *sql.DB) *Handler {
 	// テスト用のStripe設定（テストではStripe APIを呼び出さないため空でOK）
 	stripeCfg := &annictStripe.Config{}
 
-	return NewHandler(cfg, sessionManager, imageHelper, stripeSubscriberRepo, gumroadSubscriberRepo, stripeCfg)
+	// テスト用には nil を渡す（テストでは Stripe API を呼び出さない）
+	return NewHandler(cfg, sessionManager, imageHelper, stripeSubscriberRepo, gumroadSubscriberRepo, stripeCfg, nil)
 }
 
 // TestPortal_NotLoggedIn は未ログインユーザーがアクセスした場合のテスト

--- a/go/internal/handler/supporters/show_test.go
+++ b/go/internal/handler/supporters/show_test.go
@@ -37,7 +37,8 @@ func setupTestHandler(t *testing.T, tx *sql.Tx, db *sql.DB) *Handler {
 	// テスト用のStripe設定（テストではStripe APIを呼び出さないため空でOK）
 	stripeCfg := &annictStripe.Config{}
 
-	return NewHandler(cfg, sessionManager, imageHelper, stripeSubscriberRepo, gumroadSubscriberRepo, stripeCfg)
+	// テスト用には nil を渡す（テストでは Stripe API を呼び出さない）
+	return NewHandler(cfg, sessionManager, imageHelper, stripeSubscriberRepo, gumroadSubscriberRepo, stripeCfg, nil)
 }
 
 // createUserWithStripeSubscriber はStripeサブスクライバーを持つユーザーを作成します

--- a/go/internal/handler/webhooks/stripe/create_test.go
+++ b/go/internal/handler/webhooks/stripe/create_test.go
@@ -46,7 +46,7 @@ func TestCreate_SignatureValidation(t *testing.T) {
 	userRepo := repository.NewUserRepository(queries)
 
 	// UseCaseの作成
-	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo, nil)
 	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 	deleteStripeSubscriberUC := usecase.NewDeleteStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 
@@ -147,7 +147,7 @@ func TestCreate_Idempotency(t *testing.T) {
 	userRepo := repository.NewUserRepository(queries)
 
 	// UseCaseの作成
-	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo, nil)
 	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 	deleteStripeSubscriberUC := usecase.NewDeleteStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 
@@ -210,7 +210,7 @@ func TestCreate_EventProcessing(t *testing.T) {
 	userRepo := repository.NewUserRepository(queries)
 
 	// UseCaseの作成
-	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
+	createStripeSubscriberUC := usecase.NewCreateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo, nil)
 	updateStripeSubscriberUC := usecase.NewUpdateStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 	deleteStripeSubscriberUC := usecase.NewDeleteStripeSubscriberUsecase(db, stripeSubscriberRepo, userRepo)
 

--- a/go/internal/stripe/client.go
+++ b/go/internal/stripe/client.go
@@ -14,9 +14,7 @@ type Config struct {
 	PriceYearlyID  string // 年額プランの価格ID (price_xxx)
 }
 
-// Init はStripe APIクライアントを初期化します
-// Stripe SDKはグローバルにAPIキーを設定する方式を採用しているため、
-// この関数を呼び出すことでパッケージ全体でStripe APIが利用可能になります
-func Init(cfg *Config) {
-	stripe.Key = cfg.SecretKey
+// NewClient はStripe APIクライアントを作成します
+func NewClient(secretKey string) *stripe.Client {
+	return stripe.NewClient(secretKey)
 }

--- a/go/internal/usecase/create_stripe_subscriber.go
+++ b/go/internal/usecase/create_stripe_subscriber.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/stripe/stripe-go/v84"
 	"github.com/stripe/stripe-go/v84/subscription"
 
 	"github.com/annict/annict/go/internal/model"
@@ -22,6 +23,7 @@ type CreateStripeSubscriberUsecase struct {
 	db                   *sql.DB
 	stripeSubscriberRepo *repository.StripeSubscriberRepository
 	userRepo             *repository.UserRepository
+	stripeClient         *stripe.Client
 }
 
 // NewCreateStripeSubscriberUsecase はCreateStripeSubscriberUsecaseを作成します
@@ -29,11 +31,13 @@ func NewCreateStripeSubscriberUsecase(
 	db *sql.DB,
 	stripeSubscriberRepo *repository.StripeSubscriberRepository,
 	userRepo *repository.UserRepository,
+	stripeClient *stripe.Client,
 ) *CreateStripeSubscriberUsecase {
 	return &CreateStripeSubscriberUsecase{
 		db:                   db,
 		stripeSubscriberRepo: stripeSubscriberRepo,
 		userRepo:             userRepo,
+		stripeClient:         stripeClient,
 	}
 }
 


### PR DESCRIPTION
stripe-goライブラリの推奨パターン（stripe.NewClient）を採用し、
グローバル変数設定（stripe.Key）を廃止。

- internal/stripe/client.go: Init関数をNewClient関数に置き換え
- internal/handler/supporters/handler.go: *stripe.Clientを依存性として追加
- internal/usecase/create_stripe_subscriber.go: *stripe.Clientを依存性として追加
- cmd/server/main.go: クライアントを作成してハンドラー/ユースケースに渡す
- テストファイル: NewHandlerとNewCreateStripeSubscriberUsecaseにnilを追加